### PR TITLE
fix: 寄付者特典を3項目に復元

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -334,14 +334,32 @@
         <!-- Donor benefits -->
         <div class="mt-12 bg-white rounded-2xl p-8 shadow-sm border border-neutral-100 fade-in">
           <h3 class="text-lg font-bold text-neutral-900 mb-6 text-center">寄付者特典</h3>
-          <div class="flex justify-center">
+          <div class="grid sm:grid-cols-3 gap-6">
+            <div class="flex items-start gap-4">
+              <div class="w-10 h-10 bg-kaiho-purple/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                <svg class="w-5 h-5 text-kaiho-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16.5 6v.75m0 3v.75m0 3v.75m0 3V18m-9-5.25h5.25M7.5 15h3M3.375 5.25c-.621 0-1.125.504-1.125 1.125v3.026a2.999 2.999 0 010 5.198v3.026c0 .621.504 1.125 1.125 1.125h17.25c.621 0 1.125-.504 1.125-1.125v-3.026a2.999 2.999 0 010-5.198V6.375c0-.621-.504-1.125-1.125-1.125H3.375z"/></svg>
+              </div>
+              <div>
+                <h4 class="font-bold text-sm text-neutral-900">活動報告会への招待</h4>
+                <p class="text-xs text-neutral-500 mt-1">電子チケットを配布します</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-4">
+              <div class="w-10 h-10 bg-kaiho-purple/10 rounded-lg flex items-center justify-center flex-shrink-0">
+                <svg class="w-5 h-5 text-kaiho-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/></svg>
+              </div>
+              <div>
+                <h4 class="font-bold text-sm text-neutral-900">年次報告書の送付</h4>
+                <p class="text-xs text-neutral-500 mt-1">応援金の使途を透明に報告</p>
+              </div>
+            </div>
             <div class="flex items-start gap-4">
               <div class="w-10 h-10 bg-kaiho-purple/10 rounded-lg flex items-center justify-center flex-shrink-0">
                 <svg class="w-5 h-5 text-kaiho-purple" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"/></svg>
               </div>
               <div>
-                <h4 class="font-bold text-sm text-neutral-900">サイトへの掲載（ご希望の方のみ）</h4>
-                <p class="text-xs text-neutral-500 mt-1">フォーム送信時に「氏名で掲載OK」を選択された方のお名前を上記に表示します</p>
+                <h4 class="font-bold text-sm text-neutral-900">サイトへの掲載</h4>
+                <p class="text-xs text-neutral-500 mt-1">「氏名で掲載OK」をご選択の方のみ</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
PR #11 縮小時に減らしていた寄付者特典を、当初の3項目構成（活動報告会招待・年次報告書送付・サイト掲載）に復元。

🤖 Generated with [Claude Code](https://claude.com/claude-code)