### PR TITLE
security: GAS スコープ最小化 + token rotate アクション追加 (Issue #18 C1/C2)

### DIFF
--- a/scripts/gas/donations/Donations.js
+++ b/scripts/gas/donations/Donations.js
@@ -43,7 +43,9 @@ const COL_CONFIRMED_AT = 9  // J
 
 function doGet(e) {
   const token = (e && e.parameter && e.parameter.token) || ''
-  const expected = PropertiesService.getScriptProperties().getProperty('DONATIONS_TOKEN')
+  const action = (e && e.parameter && e.parameter.action) || 'fetch'
+  const props = PropertiesService.getScriptProperties()
+  const expected = props.getProperty('DONATIONS_TOKEN')
 
   if (!expected || token !== expected) {
     return ContentService
@@ -52,6 +54,14 @@ function doGet(e) {
   }
 
   try {
+    if (action === 'rotate') {
+      // 既存 token で認証済 = 同じ権限保有者と判定 → 新 token 発行
+      const newToken = Utilities.getUuid().replace(/-/g, '') + Utilities.getUuid().replace(/-/g, '')
+      props.setProperty('DONATIONS_TOKEN', newToken)
+      return ContentService
+        .createTextOutput(JSON.stringify({ rotated: true, newToken: newToken, rotatedAt: new Date().toISOString() }))
+        .setMimeType(ContentService.MimeType.JSON)
+    }
     const payload = buildPayload_()
     return ContentService
       .createTextOutput(JSON.stringify(payload))

--- a/scripts/gas/donations/appsscript.json
+++ b/scripts/gas/donations/appsscript.json
@@ -6,5 +6,8 @@
   "webapp": {
     "executeAs": "USER_DEPLOYING",
     "access": "ANYONE_ANONYMOUS"
-  }
+  },
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets"
+  ]
 }


### PR DESCRIPTION
## Summary
Issue #18 のセキュリティ精査で指摘した Critical 項目 C1/C2 への対応。

### C1: TOKEN rotate アクション
`doGet` に `?action=rotate&token=<current>` を追加。漏洩疑念時に curl 一発で安全にトークン再発行できる。実行済み — 旧 TOKEN は revoked。

### C2: OAuth スコープ削減
`script.external_request` (UrlFetchApp 未使用) と `script.scriptapp` (ScriptApp 未使用) を削除。残: `spreadsheets` のみ。

### C3: branch protection は GitHub UI レイヤーで対応済 (本 PR は適用後の最初の PR)

## 本番反映状況
GAS deployment v2 に反映済 (george 所有のため cross-domain 制約なしで直接デプロイ完了)。本 PR は repo 上の Source of Truth を一致させる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)