### PR TITLE
feat: 寄付申込フォーム送信時の LINE WORKS Bot 通知 (Issue #20 Phase 2)

### DIFF
--- a/docs/operations/line-works-notification-setup.md
+++ b/docs/operations/line-works-notification-setup.md
@@ -1,0 +1,192 @@
+# LINE WORKS 寄付通知 セットアップ手順 (Issue #20)
+
+寄付申込フォームの送信を検知し、運営トークルームへ自動通知する仕組みのセットアップ手順。
+
+> ⚠️ **秘匿情報の取扱い**
+> 本手順で扱う認証情報 6 点は **絶対にコード / リポジトリ / Slack / メール本文** に貼り付けないこと。
+> 必ず以下のいずれかに保管:
+> - LINE WORKS Developer Console (発行元)
+> - 1Password / 雄飛会の安全な共有場所
+> - Apps Script の **Script Properties** (運用反映)
+
+---
+
+## Phase 1: LINE WORKS 側のセットアップ
+
+担当: 管理者権限を持つ運営メンバー (例: 上間さん)
+
+1. [LINE WORKS Developer Console](https://dev.worksmobile.com/) に管理者アカウントでログイン
+2. **App** を新規作成
+   - 名前: 「雄飛会 寄付通知Bot 連携」
+   - スコープ: `bot` を追加
+   - Client ID / Client Secret を控える
+   - Service Account を発行し、Private Key (PEM) をダウンロード
+3. **Bot** を新規作成 (最大10個までフリープランで作成可)
+   - Bot 名: 「雄飛会 寄付通知Bot」
+   - 説明: 「寄付申込フォームの新規受付を通知します」
+   - Callback URL: 不要 (送信専用)
+   - 作成後、**Bot No. (Bot ID)** を控える
+   - 管理者画面でドメインに公開設定
+4. 通知先トークルーム
+   - 既存の運営チャンネルに Bot を招待
+   - **channelId** を取得 (Developer Console もしくは API)
+5. 取得した認証情報 6 点を 1Password / 安全な共有場所に保管
+
+### 取得すべき 6 点
+
+| 値 | 形式 | 例 |
+|---|---|---|
+| Client ID | 文字列 | `abc123xyz...` |
+| Client Secret | 文字列 | `def456uvw...` |
+| Service Account | `xxxx.serviceaccount@<domain>` | `100abc.serviceaccount@kaiho-yuhikai.com` |
+| Private Key | PEM (改行込み) | `-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----` <!-- allow-secret:pem-private-key --> |
+| Bot ID | 数値文字列 | `12345678` |
+| channelId | 文字列 | `room-channel-id` |
+
+---
+
+## Phase 2: コード反映 (開発者作業)
+
+```bash
+cd scripts/gas/donations
+clasp push
+```
+
+push されるファイル:
+- `LineWorksNotifier.js` (新規)
+- `Donations.js` (既存、変更なし)
+- `Setup.js` (Properties セットアップ + トリガー登録ヘルパー追加)
+- `appsscript.json` (`script.external_request` / `script.send_mail` / `script.scriptapp` スコープ追加)
+
+---
+
+## Phase 3: Script Properties 投入
+
+> ⚠️ 認証情報をコードにハードコードしない。GAS エディタの「実行」ダイアログから引数を渡す。
+
+### 方法 A: GAS エディタの実行ダイアログ
+
+1. GAS エディタを開く (`clasp open`)
+2. 関数選択ドロップダウンで `setupLineWorksProperties` を選ぶ
+3. 「実行」ボタンの隣の「⚙ 引数を指定して実行」をクリック
+4. 以下を貼り付けて実行:
+
+```javascript
+{
+  LW_CLIENT_ID: 'Phase 1 で取得した Client ID',
+  LW_CLIENT_SECRET: 'Phase 1 で取得した Client Secret',
+  LW_SERVICE_ACCOUNT: 'xxxx.serviceaccount@<domain>',
+  LW_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\n... (改行込みで貼り付け) ...\n-----END PRIVATE KEY-----', // allow-secret:pem-private-key
+  LW_BOT_ID: '12345678',
+  LW_CHANNEL_ID: 'channel-id-xxx',
+  ADMIN_EMAIL: 'admin@example.com'
+}
+```
+
+5. 初回は権限承認ダイアログ (UrlFetch / Mail / Spreadsheet / Trigger) が表示される → 承認
+
+### 方法 B: プロジェクト設定 → スクリプトプロパティ
+
+GAS エディタ左メニュー > プロジェクト設定 > スクリプトプロパティ > プロパティを追加。
+1 つずつ Key / Value を入力。Private Key は改行を含めて貼り付ける。
+
+---
+
+## Phase 4: 動作確認
+
+### Step 1: showProperties で投入確認
+
+GAS エディタで `showProperties` を実行。秘匿値 (LW_PRIVATE_KEY / LW_CLIENT_SECRET) は `***(length=N)` と redact されて表示される。
+
+### Step 2: testNotify で疎通テスト
+
+GAS エディタで `testNotify` を実行。運営トークルームに以下のメッセージが届くこと:
+
+```
+【テスト】寄付通知 Bot の疎通テスト (2026-MM-DD HH:MM)
+```
+
+エラーが出る場合は `docs/operations/line-works-notification-setup.md#トラブルシューティング` 参照。
+
+### Step 3: installFormSubmitTrigger でトリガー登録
+
+GAS エディタで `installFormSubmitTrigger` を実行。
+
+確認: GAS エディタ > 左メニュー > トリガー で `onFormSubmit` トリガー (Source: Spreadsheet, Event: From form) が 1 件あること。
+
+### Step 4: E2E 確認
+
+本番フォームにテスト申込を送信 → 数秒〜数十秒以内に運営トークルームへ通知が届くことを確認。
+
+通知文面例:
+```
+🎁 新しい寄付申込みがありました
+
+お名前: テスト太郎（14期）
+口数 : 1口（¥10,000）
+HP掲載: 氏名で掲載OK
+メッセージ:
+  動作確認
+
+受付: 2026-MM-DD HH:MM
+※会計確認後にサイトへ反映されます。
+スプレッドシート: https://docs.google.com/spreadsheets/d/.../edit
+```
+
+テスト行はスプレッドシートから「キャンセル」ステータスに変更するか、行ごと削除する。
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因と対処 |
+|---|---|
+| `Required Script Property missing: LW_*` | Properties が未投入。`setupLineWorksProperties({...})` を再実行 |
+| `LINE WORKS auth failed: 401` | Service Account / Client ID/Secret の組み合わせ不正。Developer Console で確認、必要なら rotate |
+| `LINE WORKS auth failed: 400` | JWT の claim 不正 (時刻ズレ / scope 不一致)。GAS のタイムゾーンが JST か確認 |
+| `LINE WORKS post failed: 403` | Bot がチャンネルに招待されていない / 送信権限なし。Bot を再招待 |
+| `LINE WORKS post failed: 404` | channelId 不正。Developer Console で再確認 |
+| 通知が遅延する (>1 分) | Apps Script のトリガーは数秒〜数十秒の遅延あり。1 分以上なら GAS の実行履歴を確認 |
+| トリガーが二重登録された | `uninstallAllTriggers()` で全削除 → `installFormSubmitTrigger()` で再登録 |
+| Private Key を誤ってコミットした | **即座に Developer Console で Service Account を rotate**。`docs/security/secret-handling.md#42-実際に秘匿情報を-commit-してしまった場合-緊急` 参照 |
+
+---
+
+## 認証情報のローテーション手順
+
+セキュリティ事故時、または年次ローテーションで認証情報を更新する:
+
+### Client Secret ローテーション
+
+1. LINE WORKS Developer Console > App > Client Secret > Re-issue
+2. 新しい Client Secret を控える
+3. GAS エディタで `setupLineWorksProperties({...})` を実行し `LW_CLIENT_SECRET` のみ更新
+4. `testNotify()` で疎通確認
+
+### Private Key ローテーション
+
+1. LINE WORKS Developer Console > App > Service Account > Private Key > Re-issue
+2. 旧 Key は即座に無効化 (Re-issue で自動)
+3. GAS エディタで `setupLineWorksProperties({...})` を実行し `LW_PRIVATE_KEY` を更新
+4. CacheService の access token を手動でクリア:
+   ```javascript
+   CacheService.getScriptCache().remove('LW_ACCESS_TOKEN_V1')
+   ```
+5. `testNotify()` で疎通確認
+
+### Bot 移管 (別ドメイン / 別アプリへ)
+
+1. 新ドメインで Phase 1 全項目を再実施
+2. `setupLineWorksProperties({...})` で 6 点すべてを上書き
+3. `testNotify()` で疎通確認
+
+---
+
+## 関連
+
+- 関連 Issue: #20, #18 (Skill 化提案)
+- 関連スクリプト: `scripts/gas/donations/LineWorksNotifier.js`, `Donations.js`, `Setup.js`
+- セキュリティガイド: `docs/security/secret-handling.md`
+- 設計記録: `docs/donation-system-implementation-plan.md`
+- LINE WORKS Developers: <https://developers.worksmobile.com/jp/docs/>
+- Bot メッセージ送信 API: <https://developers.worksmobile.com/jp/docs/bot-message-send>

--- a/scripts/gas/donations/LineWorksNotifier.js
+++ b/scripts/gas/donations/LineWorksNotifier.js
@@ -1,0 +1,217 @@
+/**
+ * 開邦雄飛会 寄付通知 — LINE WORKS Bot 連携
+ *
+ * Issue #20: フォーム送信トリガーから運営トークルームへ通知する。
+ *
+ * 認証情報は Script Properties に保存し、コードにはハードコードしない。
+ *   LW_CLIENT_ID         — Developer Console App の Client ID
+ *   LW_CLIENT_SECRET     — Developer Console App の Client Secret
+ *   LW_SERVICE_ACCOUNT   — xxxx.serviceaccount@<domain>
+ *   LW_PRIVATE_KEY       — PEM形式の Private Key (改行込み)
+ *   LW_BOT_ID            — Bot の番号
+ *   LW_CHANNEL_ID        — 送信先トークルームの channelId
+ *   ADMIN_EMAIL          — 通知失敗時のフォールバック宛先 (任意)
+ *
+ * デプロイ後 (Phase 2 → 3):
+ *   1. Script Properties に上記 6+1 点を投入
+ *   2. installFormSubmitTrigger() を 1 回だけ実行 (Setup.js)
+ *   3. testNotify() でテストルームに 1 件送信し動作確認
+ */
+
+const LW_AUTH_URL = 'https://auth.worksmobile.com/oauth2/v2.0/token'
+const LW_API_BASE = 'https://www.worksapis.com/v1.0'
+const LW_CACHE_KEY = 'LW_ACCESS_TOKEN_V1'
+const LW_TOKEN_CACHE_TTL_SEC = 60 * 50 // 50分 (LINE WORKS access token の有効期限は 1h)
+
+function getRequiredProperty_(key) {
+  const v = PropertiesService.getScriptProperties().getProperty(key)
+  if (!v) throw new Error('Required Script Property missing: ' + key)
+  return v
+}
+
+function base64UrlEncode_(s) {
+  const enc = Utilities.base64Encode(Utilities.newBlob(s).getBytes())
+  return enc.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlEncodeBytes_(bytes) {
+  const enc = Utilities.base64Encode(bytes)
+  return enc.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function createJwt_(clientId, serviceAccount, privateKey) {
+  const now = Math.floor(Date.now() / 1000)
+  const header = { typ: 'JWT', alg: 'RS256' }
+  const claims = { iss: clientId, sub: serviceAccount, iat: now, exp: now + 3600 }
+  const headerB64 = base64UrlEncode_(JSON.stringify(header))
+  const claimsB64 = base64UrlEncode_(JSON.stringify(claims))
+  const signingInput = headerB64 + '.' + claimsB64
+  const signature = Utilities.computeRsaSha256Signature(signingInput, privateKey)
+  const sigB64 = base64UrlEncodeBytes_(signature)
+  return signingInput + '.' + sigB64
+}
+
+function getAccessToken_() {
+  const cache = CacheService.getScriptCache()
+  const cached = cache.get(LW_CACHE_KEY)
+  if (cached) return cached
+
+  const clientId = getRequiredProperty_('LW_CLIENT_ID')
+  const clientSecret = getRequiredProperty_('LW_CLIENT_SECRET')
+  const serviceAccount = getRequiredProperty_('LW_SERVICE_ACCOUNT')
+  const privateKey = getRequiredProperty_('LW_PRIVATE_KEY')
+
+  const jwt = createJwt_(clientId, serviceAccount, privateKey)
+  const res = UrlFetchApp.fetch(LW_AUTH_URL, {
+    method: 'post',
+    contentType: 'application/x-www-form-urlencoded',
+    payload: {
+      assertion: jwt,
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      client_id: clientId,
+      client_secret: clientSecret,
+      scope: 'bot',
+    },
+    muteHttpExceptions: true,
+  })
+  const code = res.getResponseCode()
+  if (code !== 200) {
+    throw new Error('LINE WORKS auth failed: ' + code + ' ' + res.getContentText())
+  }
+  const json = JSON.parse(res.getContentText())
+  const token = json.access_token
+  if (!token) throw new Error('LINE WORKS auth response has no access_token')
+  cache.put(LW_CACHE_KEY, token, LW_TOKEN_CACHE_TTL_SEC)
+  return token
+}
+
+function postBotMessage_(text) {
+  const botId = getRequiredProperty_('LW_BOT_ID')
+  const channelId = getRequiredProperty_('LW_CHANNEL_ID')
+  const token = getAccessToken_()
+  const url = LW_API_BASE + '/bots/' + encodeURIComponent(botId) + '/channels/' + encodeURIComponent(channelId) + '/messages'
+  const res = UrlFetchApp.fetch(url, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { Authorization: 'Bearer ' + token },
+    payload: JSON.stringify({ content: { type: 'text', text: text } }),
+    muteHttpExceptions: true,
+  })
+  const code = res.getResponseCode()
+  if (code >= 400) {
+    throw new Error('LINE WORKS post failed: ' + code + ' ' + res.getContentText())
+  }
+  return JSON.parse(res.getContentText() || '{}')
+}
+
+function formatJpDateTime_(v) {
+  const d = v instanceof Date ? v : new Date(v)
+  if (isNaN(d.getTime())) return ''
+  const pad = (n) => String(n).padStart(2, '0')
+  return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+    ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes())
+}
+
+function getSpreadsheetUrl_() {
+  try {
+    const ssId = PropertiesService.getScriptProperties().getProperty('SPREADSHEET_ID')
+    if (ssId) return SpreadsheetApp.openById(ssId).getUrl()
+    return SpreadsheetApp.getActive().getUrl()
+  } catch (e) {
+    return ''
+  }
+}
+
+/**
+ * 行データから通知文面を組み立てる。
+ *
+ * 行構造は Donations.js の COL_* と一致 (A〜K):
+ *   row[0]  タイムスタンプ
+ *   row[1]  メール (本文には出さない)
+ *   row[2]  お名前       = COL_NAME
+ *   row[3]  入学期        = COL_PERIOD
+ *   row[4]  寄付先基金
+ *   row[5]  寄付口数      = COL_UNITS
+ *   row[6]  メッセージ    = COL_MESSAGE
+ *   row[7]  HP掲載        = COL_PUBLISH
+ */
+function buildNotificationText_(row) {
+  const ts = row[0]
+  const name = String(row[2] || '').trim()
+  const period = String(row[3] || '').trim()
+  const units = String(row[5] || '').trim()
+  const message = String(row[6] || '').trim()
+  const publish = String(row[7] || '').trim()
+  const amount = rowAmount_(row) // Donations.js で定義
+  const ssUrl = getSpreadsheetUrl_()
+  const lines = []
+  lines.push('🎁 新しい寄付申込みがありました')
+  lines.push('')
+  lines.push('お名前: ' + name + (period ? '（' + period + '）' : ''))
+  lines.push('口数 : ' + (units || '(未記入)') + '（¥' + amount.toLocaleString('en-US') + '）')
+  lines.push('HP掲載: ' + (publish || '(未記入)'))
+  lines.push('メッセージ:')
+  lines.push('  ' + (message || '(なし)'))
+  lines.push('')
+  lines.push('受付: ' + formatJpDateTime_(ts))
+  lines.push('※会計確認後にサイトへ反映されます。')
+  if (ssUrl) lines.push('スプレッドシート: ' + ssUrl)
+  return lines.join('\n')
+}
+
+function notifyAdminFailure_(err) {
+  const adminEmail = PropertiesService.getScriptProperties().getProperty('ADMIN_EMAIL')
+  if (!adminEmail) return
+  try {
+    MailApp.sendEmail({
+      to: adminEmail,
+      subject: '[雄飛会] 寄付通知失敗',
+      body: '寄付申込の LINE WORKS 通知に失敗しました。\n\n' +
+        '原因: ' + (err && err.message || err) + '\n\n' +
+        'スプレッドシートを直接確認してください。',
+    })
+  } catch (mailErr) {
+    Logger.log('[notifyAdminFailure_] mail send failed: ' + mailErr)
+  }
+}
+
+/**
+ * Form 送信時に Apps Script のトリガーから呼ばれる。
+ *
+ * e.range が submit された行の Range を提供する (A〜K の 11 列)。
+ * 例外は throw せず、Logger + 管理者メールでフォールバックする (寄付申込自体は完了させる)。
+ */
+function onFormSubmit(e) {
+  try {
+    let row
+    if (e && e.range && typeof e.range.getRow === 'function') {
+      const r = e.range.getRow()
+      const ssId = PropertiesService.getScriptProperties().getProperty('SPREADSHEET_ID')
+      const ss = ssId ? SpreadsheetApp.openById(ssId) : SpreadsheetApp.getActive()
+      const sheet = ss.getSheetByName('donations') || ss.getSheets()[0]
+      row = sheet.getRange(r, 1, 1, 11).getValues()[0]
+    } else if (e && e.range && typeof e.range.getValues === 'function') {
+      row = e.range.getValues()[0]
+    } else if (e && e.values) {
+      // フォールバック: namedValues / values から組み立て
+      row = [new Date()].concat(e.values || [])
+    } else {
+      throw new Error('onFormSubmit: row data not available from event')
+    }
+    const text = buildNotificationText_(row)
+    postBotMessage_(text)
+  } catch (err) {
+    Logger.log('[onFormSubmit] error: ' + (err && err.stack || err))
+    notifyAdminFailure_(err)
+  }
+}
+
+/**
+ * GAS エディタから手動実行して通知の動作確認をする。
+ * Bot トークルームに簡単なメッセージを 1 件送る。
+ */
+function testNotify() {
+  const text = '【テスト】寄付通知 Bot の疎通テスト (' + formatJpDateTime_(new Date()) + ')'
+  postBotMessage_(text)
+  Logger.log('testNotify: sent')
+}

--- a/scripts/gas/donations/README.md
+++ b/scripts/gas/donations/README.md
@@ -5,8 +5,9 @@
 ## 構成ファイル
 
 - `Donations.js` — `doGet()` を提供する Web アプリ本体（HP連携用 JSON エンドポイント）
-- `Setup.js` — `setupAll()` 一発で Sheet + Form を作成・連携・整形（**新規構築用ヘルパ。既存リソース利用時は実行不要**）
-- `appsscript.json` — マニフェスト（Web アプリ設定 + タイムゾーン JST）
+- `LineWorksNotifier.js` — フォーム送信時に LINE WORKS Bot で運営トークルームへ通知（Issue #20）
+- `Setup.js` — `setupAll()` 一発で Sheet + Form を作成・連携・整形、`setupLineWorksProperties()` / `installFormSubmitTrigger()` 等のヘルパも提供
+- `appsscript.json` — マニフェスト（Web アプリ設定 + タイムゾーン JST + 必要 OAuth スコープ）
 
 ## セットアップ手順
 
@@ -121,3 +122,38 @@ clasp deploy --deploymentId <ID> --description "v2: ..."
 | `forbidden` が返る | GitHub Secrets の `DONATIONS_ENDPOINT_TOKEN` と Script Properties `DONATIONS_TOKEN` が一致しているか確認 |
 | `Donations sheet not found` | スプレッドシートに「フォームの回答」が含まれるシートがあるか確認、無ければ Form 連携が切れている |
 | 金額が 0 になる | E列が「10,000円」or「その他...」、F列が数値かを確認 |
+| LINE WORKS 通知が来ない | (1) `showProperties()` で `LW_*` 6 点が全て入っているか / (2) GAS エディタで `testNotify()` を実行して 200 が返るか / (3) `installFormSubmitTrigger()` を実行済か / (4) Bot がチャンネルに招待されているか |
+| `Required Script Property missing` | `setupLineWorksProperties({...})` を再実行して 6 点を投入 |
+| `LINE WORKS auth failed: 401` | Service Account / Client ID/Secret の組み合わせを確認、再発行が必要なら Developer Console から rotate |
+| `LINE WORKS post failed: 403` | Bot に対象 channelId への送信権限があるか確認 (Bot を再招待) |
+
+## LINE WORKS Bot 通知 (Issue #20)
+
+詳細手順は `docs/operations/line-works-notification-setup.md` を参照。
+
+### サマリ
+
+1. LINE WORKS Developer Console で App + Bot を作成し、認証情報 6 点を取得
+2. `clasp push` でコードを反映
+3. GAS エディタから `setupLineWorksProperties({...})` を 1 回実行して Properties を投入
+4. `testNotify()` でトークルームへの疎通確認
+5. `installFormSubmitTrigger()` でフォーム送信トリガーを登録
+
+### Script Properties (LINE WORKS 関連)
+
+| Key | 説明 | 必須 |
+|---|---|---|
+| `LW_CLIENT_ID` | Developer Console App の Client ID | ✓ |
+| `LW_CLIENT_SECRET` | Developer Console App の Client Secret | ✓ |
+| `LW_SERVICE_ACCOUNT` | `xxxx.serviceaccount@<domain>` | ✓ |
+| `LW_PRIVATE_KEY` | PEM形式の Private Key (改行込み) | ✓ |
+| `LW_BOT_ID` | Bot の番号 | ✓ |
+| `LW_CHANNEL_ID` | 送信先トークルームの channelId | ✓ |
+| `ADMIN_EMAIL` | 通知失敗時の管理者メール宛先 | (推奨) |
+
+### 緊急停止
+
+```javascript
+// GAS エディタで実行
+uninstallAllTriggers()
+```

--- a/scripts/gas/donations/Setup.js
+++ b/scripts/gas/donations/Setup.js
@@ -229,10 +229,106 @@ function ensureSheetStructure_(ss, form) {
 
 /**
  * デバッグ用: 現在保存されている Properties を表示
+ * 注意: 秘匿値 (LW_PRIVATE_KEY / TOKEN 等) は redact してログ出力する。
  */
 function showProperties() {
   const props = PropertiesService.getScriptProperties().getProperties()
-  Logger.log(JSON.stringify(props, null, 2))
+  const SENSITIVE_KEYS = ['LW_PRIVATE_KEY', 'LW_CLIENT_SECRET', 'DONATIONS_TOKEN']
+  const redacted = {}
+  for (const k of Object.keys(props)) {
+    if (SENSITIVE_KEYS.indexOf(k) >= 0) {
+      const v = String(props[k] || '')
+      redacted[k] = v ? '***(length=' + v.length + ')' : '(empty)'
+    } else {
+      redacted[k] = props[k]
+    }
+  }
+  Logger.log(JSON.stringify(redacted, null, 2))
+}
+
+/**
+ * LINE WORKS Bot 通知用の Script Properties を一括投入する (Issue #20)。
+ *
+ * Phase 1 (LINE WORKS Developer Console) で取得した 6 点 + ADMIN_EMAIL を引数で渡す。
+ * GAS エディタから呼ぶ場合は params を直接書く / clasp run-function でも可。
+ *
+ * 例:
+ *   setupLineWorksProperties({
+ *     LW_CLIENT_ID:       '...',
+ *     LW_CLIENT_SECRET:   '...',
+ *     LW_SERVICE_ACCOUNT: 'xxx.serviceaccount@<domain>',
+ *     LW_PRIVATE_KEY:     '<<PEM形式の秘密鍵テキスト (改行込み)>>',
+ *     LW_BOT_ID:          '12345678',
+ *     LW_CHANNEL_ID:      '...',
+ *     ADMIN_EMAIL:        'admin@example.com',
+ *   })
+ *
+ * 注意: コードにハードコードして clasp push しないこと。
+ *       GAS エディタの「実行」入力欄に引数を貼り付けるか、
+ *       「プロジェクト設定 → スクリプトプロパティ」から手入力する。
+ */
+function setupLineWorksProperties(params) {
+  if (!params || typeof params !== 'object') {
+    throw new Error('setupLineWorksProperties: params (object) is required')
+  }
+  const REQUIRED = ['LW_CLIENT_ID', 'LW_CLIENT_SECRET', 'LW_SERVICE_ACCOUNT', 'LW_PRIVATE_KEY', 'LW_BOT_ID', 'LW_CHANNEL_ID']
+  const missing = []
+  for (const k of REQUIRED) {
+    if (!params[k]) missing.push(k)
+  }
+  if (missing.length > 0) {
+    throw new Error('setupLineWorksProperties: 必須キーが不足 (missing: ' + missing.join(', ') + ')')
+  }
+  const props = PropertiesService.getScriptProperties()
+  for (const k of REQUIRED) {
+    props.setProperty(k, String(params[k]))
+  }
+  if (params.ADMIN_EMAIL) {
+    props.setProperty('ADMIN_EMAIL', String(params.ADMIN_EMAIL))
+  }
+  Logger.log('LINE WORKS Properties を設定しました: ' + REQUIRED.join(', ') +
+    (params.ADMIN_EMAIL ? ', ADMIN_EMAIL' : ''))
+  return { saved: REQUIRED.concat(params.ADMIN_EMAIL ? ['ADMIN_EMAIL'] : []) }
+}
+
+/**
+ * フォーム送信トリガーを 1 個だけ登録する (Issue #20)。
+ *
+ * 既に同名トリガーがある場合は削除してから再登録する (重複登録を回避)。
+ *
+ * 実行は GAS エディタで関数 installFormSubmitTrigger を選んで「▶ 実行」。
+ * 初回は権限承認が走る (UrlFetchApp / MailApp / Spreadsheet)。
+ */
+function installFormSubmitTrigger() {
+  const props = PropertiesService.getScriptProperties()
+  const ssId = props.getProperty('SPREADSHEET_ID')
+  if (!ssId) throw new Error('SPREADSHEET_ID 未設定。runBootstrap を先に実行してください。')
+  const ss = SpreadsheetApp.openById(ssId)
+
+  // 既存の onFormSubmit トリガーを削除
+  const existing = ScriptApp.getProjectTriggers()
+  let removed = 0
+  for (const t of existing) {
+    if (t.getHandlerFunction() === 'onFormSubmit') {
+      ScriptApp.deleteTrigger(t)
+      removed++
+    }
+  }
+
+  // 新規登録 (Sheet ベースの onFormSubmit)
+  ScriptApp.newTrigger('onFormSubmit').forSpreadsheet(ss).onFormSubmit().create()
+  Logger.log('installFormSubmitTrigger: removed=' + removed + ' / installed=1')
+  return { removed: removed, installed: 1 }
+}
+
+/**
+ * 登録済みトリガーを全て削除する (緊急停止用)。
+ */
+function uninstallAllTriggers() {
+  const triggers = ScriptApp.getProjectTriggers()
+  for (const t of triggers) ScriptApp.deleteTrigger(t)
+  Logger.log('uninstallAllTriggers: removed=' + triggers.length)
+  return { removed: triggers.length }
 }
 
 /**

--- a/scripts/gas/donations/appsscript.json
+++ b/scripts/gas/donations/appsscript.json
@@ -8,6 +8,9 @@
     "access": "ANYONE_ANONYMOUS"
   },
   "oauthScopes": [
-    "https://www.googleapis.com/auth/spreadsheets"
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/script.send_mail",
+    "https://www.googleapis.com/auth/script.scriptapp"
   ]
 }

--- a/tests/gas-harness.mjs
+++ b/tests/gas-harness.mjs
@@ -1,0 +1,191 @@
+/**
+ * GAS スクリプトを Node.js vm sandbox で実行するヘルパ
+ *
+ * GAS は CommonJS / ES Module ではなく独自の global scope モデル。
+ * vm.runInContext で `function fn() {}` 宣言は context.globalThis に登録される。
+ * `const` / `let` は script スコープに閉じるため、テスト側からは関数呼び出しでアクセスする。
+ *
+ * 使い方:
+ *   const ctx = createGasContext({ PropertiesService: mockProps(), ... })
+ *   loadGasFile(ctx, 'scripts/gas/donations/LineWorksNotifier.js')
+ *   const result = callGas(ctx, 'buildNotificationText_', [row])
+ */
+
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+
+export function createGasContext(globals = {}) {
+  const sandbox = {
+    console,
+    JSON,
+    Date,
+    Math,
+    String,
+    Number,
+    Boolean,
+    Array,
+    Object,
+    Error,
+    RegExp,
+    encodeURIComponent,
+    decodeURIComponent,
+    setTimeout: () => {},
+    clearTimeout: () => {},
+    ...globals,
+  }
+  return vm.createContext(sandbox)
+}
+
+export function loadGasFile(ctx, filePath) {
+  const src = readFileSync(filePath, 'utf8')
+  vm.runInContext(src, ctx, { filename: filePath })
+}
+
+export function callGas(ctx, fnName, args = []) {
+  ctx.__args__ = args
+  try {
+    return vm.runInContext(`${fnName}.apply(null, __args__)`, ctx)
+  } finally {
+    delete ctx.__args__
+  }
+}
+
+export function evalGas(ctx, code) {
+  return vm.runInContext(code, ctx)
+}
+
+// ---- 標準モック工場 ----
+
+export function makePropertiesService(initial = {}) {
+  const store = { ...initial }
+  const props = {
+    getProperty: (k) => (k in store ? store[k] : null),
+    setProperty: (k, v) => { store[k] = String(v); return props },
+    deleteProperty: (k) => { delete store[k]; return props },
+    getProperties: () => ({ ...store }),
+    _store: store,
+  }
+  return {
+    getScriptProperties: () => props,
+    getUserProperties: () => props,
+    getDocumentProperties: () => props,
+  }
+}
+
+export function makeCacheService(initial = {}) {
+  const store = { ...initial }
+  const cache = {
+    get: (k) => (k in store ? store[k] : null),
+    put: (k, v, _ttl) => { store[k] = String(v) },
+    remove: (k) => { delete store[k] },
+    _store: store,
+  }
+  return {
+    getScriptCache: () => cache,
+    getUserCache: () => cache,
+    getDocumentCache: () => cache,
+  }
+}
+
+export function makeUrlFetchApp(handler) {
+  // handler: (url, opts) => { code, body, headers? }
+  const calls = []
+  const app = {
+    fetch: (url, opts = {}) => {
+      calls.push({ url, opts })
+      const res = handler(url, opts) || { code: 200, body: '{}' }
+      return {
+        getResponseCode: () => res.code,
+        getContentText: () => res.body,
+        getAllHeaders: () => res.headers || {},
+      }
+    },
+    _calls: calls,
+  }
+  return app
+}
+
+export function makeUtilities({ sha256Sig = 'SIG_BYTES' } = {}) {
+  return {
+    base64Encode: (input) => {
+      const buf = typeof input === 'string'
+        ? Buffer.from(input, 'utf8')
+        : Buffer.from(input)
+      return buf.toString('base64')
+    },
+    base64EncodeWebSafe: (input) => {
+      const buf = typeof input === 'string'
+        ? Buffer.from(input, 'utf8')
+        : Buffer.from(input)
+      return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+    },
+    newBlob: (s) => ({
+      getBytes: () => Buffer.from(s, 'utf8'),
+    }),
+    computeRsaSha256Signature: (_data, _privateKey) => {
+      // バイト配列を返す (内容は決定的)
+      return Buffer.from(sha256Sig, 'utf8')
+    },
+    getUuid: () => 'uuid-mock-1234',
+    formatDate: (date, _tz, format) => {
+      const d = date instanceof Date ? date : new Date(date)
+      return d.toISOString().replace('T', ' ').slice(0, 16)
+    },
+  }
+}
+
+export function makeLogger() {
+  const lines = []
+  return {
+    log: (m, ...rest) => {
+      const s = rest.length ? [m, ...rest].join(' ') : String(m)
+      lines.push(s)
+    },
+    _lines: lines,
+  }
+}
+
+export function makeMailApp() {
+  const sent = []
+  return {
+    sendEmail: (toOrParams, subject, body) => {
+      if (typeof toOrParams === 'object') {
+        sent.push(toOrParams)
+      } else {
+        sent.push({ to: toOrParams, subject, body })
+      }
+    },
+    _sent: sent,
+  }
+}
+
+export function makeSpreadsheetApp({ url = 'https://docs.google.com/spreadsheets/d/MOCK_ID/edit', name = 'mock', rows = [] } = {}) {
+  const sheet = {
+    getName: () => 'donations',
+    getLastRow: () => rows.length + 1,
+    getRange: (row, col, numRows, numCols) => ({
+      getValues: () => {
+        if (typeof row === 'number' && typeof col === 'number') {
+          const r = row - 1
+          if (r < 0 || r >= rows.length) return [[]]
+          return [rows[r].slice(col - 1, col - 1 + (numCols || rows[r].length))]
+        }
+        return [rows[0] || []]
+      },
+      getValue: () => (rows[row - 1] || [])[col - 1],
+    }),
+  }
+  const ss = {
+    getName: () => name,
+    getUrl: () => url,
+    getId: () => 'MOCK_ID',
+    getSheetByName: () => sheet,
+    getSheets: () => [sheet],
+  }
+  return {
+    openById: () => ss,
+    getActive: () => ss,
+    _ss: ss,
+    _sheet: sheet,
+  }
+}

--- a/tests/line-works-notifier.test.mjs
+++ b/tests/line-works-notifier.test.mjs
@@ -317,7 +317,7 @@ describe('Setup.js — LINE WORKS Properties セットアップ', () => {
     callGas(ctx, 'setupLineWorksProperties', [{
       LW_CLIENT_ID: 'cid',
       LW_CLIENT_SECRET: 'csec',
-      LW_SERVICE_ACCOUNT: 'svc@e.com',
+      LW_SERVICE_ACCOUNT: 'svc@example.com',
       LW_PRIVATE_KEY: '-----BEGIN ' + 'PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----',
       LW_BOT_ID: 'bot1',
       LW_CHANNEL_ID: 'ch1',
@@ -325,7 +325,7 @@ describe('Setup.js — LINE WORKS Properties セットアップ', () => {
     const store = evalGas(ctx, 'PropertiesService.getScriptProperties().getProperties()')
     expect(store.LW_CLIENT_ID).toBe('cid')
     expect(store.LW_CLIENT_SECRET).toBe('csec')
-    expect(store.LW_SERVICE_ACCOUNT).toBe('svc@e.com')
+    expect(store.LW_SERVICE_ACCOUNT).toBe('svc@example.com')
     expect(store.LW_PRIVATE_KEY).toContain('BEGIN')
     expect(store.LW_BOT_ID).toBe('bot1')
     expect(store.LW_CHANNEL_ID).toBe('ch1')

--- a/tests/line-works-notifier.test.mjs
+++ b/tests/line-works-notifier.test.mjs
@@ -1,0 +1,349 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { resolve } from 'node:path'
+import { readFileSync } from 'node:fs'
+import {
+  createGasContext, loadGasFile, callGas, evalGas,
+  makePropertiesService, makeCacheService, makeUrlFetchApp,
+  makeUtilities, makeLogger, makeMailApp, makeSpreadsheetApp,
+} from './gas-harness.mjs'
+
+const NOTIFIER_PATH = resolve(process.cwd(), 'scripts/gas/donations/LineWorksNotifier.js')
+const DONATIONS_PATH = resolve(process.cwd(), 'scripts/gas/donations/Donations.js')
+const APPSSCRIPT_PATH = resolve(process.cwd(), 'scripts/gas/donations/appsscript.json')
+
+const REQUIRED_PROPS = {
+  LW_CLIENT_ID: 'client-id-xxx',
+  LW_CLIENT_SECRET: 'client-secret-xxx',
+  LW_SERVICE_ACCOUNT: 'svc.account@example.com',
+  LW_PRIVATE_KEY: '-----BEGIN ' + 'PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----',
+  LW_BOT_ID: '12345678',
+  LW_CHANNEL_ID: 'channel-id-yyy',
+  SPREADSHEET_ID: 'MOCK_SHEET_ID',
+  ADMIN_EMAIL: 'admin@example.com',
+}
+
+function makeCtx({ props = REQUIRED_PROPS, fetchHandler, rows = [] } = {}) {
+  const propsService = makePropertiesService(props)
+  const cacheService = makeCacheService()
+  const fetchApp = makeUrlFetchApp(fetchHandler || (() => ({ code: 200, body: JSON.stringify({ access_token: 'AT_VAL', expires_in: 3600 }) })))
+  const utilities = makeUtilities()
+  const logger = makeLogger()
+  const mailApp = makeMailApp()
+  const ssApp = makeSpreadsheetApp({ rows })
+  const ctx = createGasContext({
+    PropertiesService: propsService,
+    CacheService: cacheService,
+    UrlFetchApp: fetchApp,
+    Utilities: utilities,
+    Logger: logger,
+    MailApp: mailApp,
+    SpreadsheetApp: ssApp,
+  })
+  // Donations.js を先にロード (LineWorksNotifier が rowAmount_ を参照するため)
+  loadGasFile(ctx, DONATIONS_PATH)
+  loadGasFile(ctx, NOTIFIER_PATH)
+  return { ctx, fetchApp, logger, mailApp, propsService, cacheService, ssApp }
+}
+
+// row 構造: A=ts, B=email, C=name, D=period, E=fund, F=units, G=message, H=publish, I=status, J=confirmedAt, K=confirmer
+function makeRow({
+  ts = new Date('2026-05-13T11:23:00+09:00'),
+  email = 'donor@example.com',
+  name = '山田 太郎',
+  period = '5期',
+  fund = '開邦雄飛応援金',
+  units = '2口',
+  message = '応援しています！',
+  publish = '氏名で掲載OK',
+  status = '未確認',
+  confirmedAt = '',
+  confirmer = '',
+} = {}) {
+  return [ts, email, name, period, fund, units, message, publish, status, confirmedAt, confirmer]
+}
+
+describe('buildNotificationText_', () => {
+  it('Issue #20 仕様の文面を組み立てる', () => {
+    const { ctx } = makeCtx()
+    const row = makeRow()
+    const text = callGas(ctx, 'buildNotificationText_', [row])
+    expect(text).toContain('🎁 新しい寄付申込みがありました')
+    expect(text).toContain('お名前: 山田 太郎（5期）')
+    expect(text).toContain('口数 : 2口（¥20,000）')
+    expect(text).toContain('HP掲載: 氏名で掲載OK')
+    expect(text).toContain('応援しています！')
+    expect(text).toContain('受付: 2026-05-13')
+    expect(text).toContain('※会計確認後にサイトへ反映されます。')
+    expect(text).toContain('スプレッドシート: ')
+  })
+
+  it('メッセージなしの場合 "(なし)" と表示する', () => {
+    const { ctx } = makeCtx()
+    const row = makeRow({ message: '' })
+    const text = callGas(ctx, 'buildNotificationText_', [row])
+    expect(text).toContain('(なし)')
+  })
+
+  it('期不明の場合は期表記を省略する', () => {
+    const { ctx } = makeCtx()
+    const row = makeRow({ period: '' })
+    const text = callGas(ctx, 'buildNotificationText_', [row])
+    expect(text).toContain('お名前: 山田 太郎')
+    expect(text).not.toMatch(/お名前: 山田 太郎（[^）]+）/)
+  })
+
+  it('Email アドレスは本文に出さない (公開ログを避ける)', () => {
+    const { ctx } = makeCtx()
+    const row = makeRow({ email: 'private@example.com' })
+    const text = callGas(ctx, 'buildNotificationText_', [row])
+    expect(text).not.toContain('private@example.com')
+  })
+
+  it('「その他」金額の場合は ¥10,000 換算で表示する (rowAmount_ 連動)', () => {
+    const { ctx } = makeCtx()
+    const row = makeRow({ units: 'その他' })
+    const text = callGas(ctx, 'buildNotificationText_', [row])
+    expect(text).toContain('¥10,000')
+  })
+})
+
+describe('getAccessToken_', () => {
+  it('Script Properties が欠けていると throw する', () => {
+    const { ctx } = makeCtx({ props: { ...REQUIRED_PROPS, LW_CLIENT_ID: '' } })
+    expect(() => callGas(ctx, 'getAccessToken_', [])).toThrow(/LW_CLIENT_ID/)
+  })
+
+  it('cache hit の場合 fetch せずキャッシュ値を返す', () => {
+    const { ctx, fetchApp, cacheService } = makeCtx()
+    cacheService.getScriptCache().put('LW_ACCESS_TOKEN_V1', 'CACHED_TOKEN', 1800)
+    const tok = callGas(ctx, 'getAccessToken_', [])
+    expect(tok).toBe('CACHED_TOKEN')
+    expect(fetchApp._calls.length).toBe(0)
+  })
+
+  it('cache miss の場合は auth endpoint を叩いて access_token を返す', () => {
+    const { ctx, fetchApp } = makeCtx({
+      fetchHandler: (url, opts) => {
+        if (url.includes('/oauth2/v2.0/token')) {
+          return { code: 200, body: JSON.stringify({ access_token: 'NEW_TOKEN', expires_in: 3600 }) }
+        }
+        return { code: 500, body: 'unexpected' }
+      },
+    })
+    const tok = callGas(ctx, 'getAccessToken_', [])
+    expect(tok).toBe('NEW_TOKEN')
+    expect(fetchApp._calls[0].url).toMatch(/auth\.worksmobile\.com\/oauth2\/v2\.0\/token/)
+    expect(fetchApp._calls[0].opts.method).toBe('post')
+    expect(fetchApp._calls[0].opts.payload.grant_type).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer')
+  })
+
+  it('auth endpoint が 4xx/5xx の場合 throw する', () => {
+    const { ctx } = makeCtx({
+      fetchHandler: () => ({ code: 401, body: 'unauthorized' }),
+    })
+    expect(() => callGas(ctx, 'getAccessToken_', [])).toThrow(/401/)
+  })
+
+  it('成功時 access_token を cache に保存する', () => {
+    const { ctx, cacheService } = makeCtx({
+      fetchHandler: () => ({ code: 200, body: JSON.stringify({ access_token: 'STORED', expires_in: 3600 }) }),
+    })
+    callGas(ctx, 'getAccessToken_', [])
+    expect(cacheService.getScriptCache().get('LW_ACCESS_TOKEN_V1')).toBe('STORED')
+  })
+})
+
+describe('createJwt_', () => {
+  it('header.payload.signature の 3 セグメントを返す', () => {
+    const { ctx } = makeCtx()
+    const jwt = callGas(ctx, 'createJwt_', ['client-x', 'svc@example.com', 'priv-key-stub'])
+    const segs = jwt.split('.')
+    expect(segs.length).toBe(3)
+    for (const s of segs) {
+      expect(s).toMatch(/^[A-Za-z0-9_-]+$/)
+    }
+  })
+
+  it('header に alg=RS256 が含まれる', () => {
+    const { ctx } = makeCtx()
+    const jwt = callGas(ctx, 'createJwt_', ['client-x', 'svc@example.com', 'priv-key-stub'])
+    const headerJson = Buffer.from(jwt.split('.')[0], 'base64').toString('utf8')
+    const header = JSON.parse(headerJson)
+    expect(header.alg).toBe('RS256')
+    expect(header.typ).toBe('JWT')
+  })
+
+  it('claim に iss=client_id / sub=service_account / iat / exp を含む', () => {
+    const { ctx } = makeCtx()
+    const jwt = callGas(ctx, 'createJwt_', ['client-x', 'svc@example.com', 'priv-key-stub'])
+    const claimsJson = Buffer.from(jwt.split('.')[1], 'base64').toString('utf8')
+    const claims = JSON.parse(claimsJson)
+    expect(claims.iss).toBe('client-x')
+    expect(claims.sub).toBe('svc@example.com')
+    expect(typeof claims.iat).toBe('number')
+    expect(typeof claims.exp).toBe('number')
+    expect(claims.exp).toBeGreaterThan(claims.iat)
+  })
+})
+
+describe('postBotMessage_', () => {
+  it('Bot Message API に Bearer header 付きで POST する', () => {
+    let posted
+    const { ctx, fetchApp } = makeCtx({
+      fetchHandler: (url, opts) => {
+        if (url.includes('/oauth2/v2.0/token')) {
+          return { code: 200, body: JSON.stringify({ access_token: 'AT', expires_in: 3600 }) }
+        }
+        if (url.includes('/messages')) {
+          posted = { url, opts }
+          return { code: 200, body: '{}' }
+        }
+        return { code: 404, body: 'not found' }
+      },
+    })
+    callGas(ctx, 'postBotMessage_', ['hello'])
+    expect(posted.url).toMatch(/worksapis\.com\/v1\.0\/bots\/[^/]+\/channels\/[^/]+\/messages/)
+    expect(posted.opts.method).toBe('post')
+    expect(posted.opts.headers.Authorization).toBe('Bearer AT')
+    const body = JSON.parse(posted.opts.payload)
+    expect(body.content.type).toBe('text')
+    expect(body.content.text).toBe('hello')
+  })
+
+  it('Bot API が 4xx の場合 throw する', () => {
+    const { ctx } = makeCtx({
+      fetchHandler: (url) => {
+        if (url.includes('/oauth2/')) return { code: 200, body: JSON.stringify({ access_token: 'AT', expires_in: 3600 }) }
+        return { code: 400, body: 'bad request' }
+      },
+    })
+    expect(() => callGas(ctx, 'postBotMessage_', ['x'])).toThrow(/400/)
+  })
+})
+
+describe('onFormSubmit', () => {
+  it('成功時に postBotMessage を 1 回呼ぶ', () => {
+    const calls = []
+    const { ctx, fetchApp } = makeCtx({
+      fetchHandler: (url, opts) => {
+        if (url.includes('/oauth2/')) {
+          calls.push('token')
+          return { code: 200, body: JSON.stringify({ access_token: 'AT', expires_in: 3600 }) }
+        }
+        if (url.includes('/messages')) {
+          calls.push('msg:' + JSON.parse(opts.payload).content.text.slice(0, 30))
+          return { code: 200, body: '{}' }
+        }
+        return { code: 404, body: 'nf' }
+      },
+    })
+    const row = makeRow()
+    const e = {
+      range: {
+        getRow: () => 2,
+        getValues: () => [row],
+      },
+      values: row.slice(1), // Form values は timestamp を除く
+    }
+    callGas(ctx, 'onFormSubmit', [e])
+    expect(calls).toEqual(['token', expect.stringContaining('msg:')])
+  })
+
+  it('postBotMessage 失敗時に Logger.log + 管理者メール送信する', () => {
+    const { ctx, logger, mailApp } = makeCtx({
+      fetchHandler: (url) => {
+        if (url.includes('/oauth2/')) return { code: 500, body: 'token down' }
+        return { code: 500, body: 'down' }
+      },
+    })
+    const e = {
+      range: {
+        getRow: () => 2,
+        getValues: () => [makeRow()],
+      },
+      values: [],
+    }
+    // throw しない (運用継続のため)
+    callGas(ctx, 'onFormSubmit', [e])
+    expect(logger._lines.join('\n')).toMatch(/onFormSubmit.*error/i)
+    expect(mailApp._sent.length).toBeGreaterThan(0)
+    expect(mailApp._sent[0].to).toBe('admin@example.com')
+    expect(mailApp._sent[0].subject).toMatch(/通知失敗|寄付/)
+  })
+})
+
+describe('testNotify', () => {
+  it('テスト用通知を 1 回送信する', () => {
+    const calls = []
+    const { ctx } = makeCtx({
+      fetchHandler: (url, opts) => {
+        if (url.includes('/oauth2/')) return { code: 200, body: JSON.stringify({ access_token: 'AT', expires_in: 3600 }) }
+        if (url.includes('/messages')) {
+          calls.push(JSON.parse(opts.payload).content.text)
+          return { code: 200, body: '{}' }
+        }
+        return { code: 404, body: '' }
+      },
+    })
+    callGas(ctx, 'testNotify', [])
+    expect(calls.length).toBe(1)
+    expect(calls[0]).toMatch(/テスト|test/i)
+  })
+})
+
+describe('appsscript.json (manifest)', () => {
+  it('script.external_request スコープが追加されている', () => {
+    const json = JSON.parse(readFileSync(APPSSCRIPT_PATH, 'utf8'))
+    expect(json.oauthScopes).toContain('https://www.googleapis.com/auth/script.external_request')
+  })
+
+  it('script.send_mail スコープが追加されている (失敗時の管理者メール送信用)', () => {
+    const json = JSON.parse(readFileSync(APPSSCRIPT_PATH, 'utf8'))
+    expect(json.oauthScopes).toContain('https://www.googleapis.com/auth/script.send_mail')
+  })
+})
+
+describe('Setup.js — LINE WORKS Properties セットアップ', () => {
+  it('setupLineWorksProperties が 6 点の必須キーを引数から保存する', () => {
+    const SETUP_PATH = resolve(process.cwd(), 'scripts/gas/donations/Setup.js')
+    const ctx = createGasContext({
+      PropertiesService: makePropertiesService(),
+      Logger: makeLogger(),
+      Utilities: makeUtilities(),
+      SpreadsheetApp: makeSpreadsheetApp(),
+      FormApp: { create: () => ({ setTitle: () => {}, setDescription: () => {} }) },
+    })
+    loadGasFile(ctx, SETUP_PATH)
+    callGas(ctx, 'setupLineWorksProperties', [{
+      LW_CLIENT_ID: 'cid',
+      LW_CLIENT_SECRET: 'csec',
+      LW_SERVICE_ACCOUNT: 'svc@e.com',
+      LW_PRIVATE_KEY: '-----BEGIN ' + 'PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----',
+      LW_BOT_ID: 'bot1',
+      LW_CHANNEL_ID: 'ch1',
+    }])
+    const store = evalGas(ctx, 'PropertiesService.getScriptProperties().getProperties()')
+    expect(store.LW_CLIENT_ID).toBe('cid')
+    expect(store.LW_CLIENT_SECRET).toBe('csec')
+    expect(store.LW_SERVICE_ACCOUNT).toBe('svc@e.com')
+    expect(store.LW_PRIVATE_KEY).toContain('BEGIN')
+    expect(store.LW_BOT_ID).toBe('bot1')
+    expect(store.LW_CHANNEL_ID).toBe('ch1')
+  })
+
+  it('setupLineWorksProperties は必須キーが欠けると throw する', () => {
+    const SETUP_PATH = resolve(process.cwd(), 'scripts/gas/donations/Setup.js')
+    const ctx = createGasContext({
+      PropertiesService: makePropertiesService(),
+      Logger: makeLogger(),
+      Utilities: makeUtilities(),
+      SpreadsheetApp: makeSpreadsheetApp(),
+      FormApp: { create: () => ({ setTitle: () => {}, setDescription: () => {} }) },
+    })
+    loadGasFile(ctx, SETUP_PATH)
+    expect(() => callGas(ctx, 'setupLineWorksProperties', [{
+      LW_CLIENT_ID: 'cid',
+      // missing others
+    }])).toThrow(/必須|required|missing/i)
+  })
+})


### PR DESCRIPTION
Closes #20 (Phase 2 のコード実装まで。Phase 3〜5 = 運用者によるデプロイ + Properties 投入 + トリガー登録は別途)

## Summary

寄付申込フォーム送信時に LINE WORKS 運営トークルームへ即時通知する仕組みを追加。
TDD (RED → GREEN → REFACTOR) で実装、22 件の vitest テスト追加 / 全 74 件 pass。

> **Stack 注意**: 本 PR は #21 (秘匿情報漏洩防止ハーネス) を依存先にしています。先に #21 をマージしてください。

## 実装内容

### 新規ファイル
- `scripts/gas/donations/LineWorksNotifier.js` — Bot API v2.0 連携本体
- `scripts/gas/donations/` 配下に既存 `Donations.js` / `Setup.js` / `appsscript.json` への変更
- `tests/gas-harness.mjs` — vm sandbox + GAS API モック (PropertiesService / CacheService / UrlFetchApp / Utilities / Logger / MailApp / SpreadsheetApp)
- `tests/line-works-notifier.test.mjs` — 22 件
- `docs/operations/line-works-notification-setup.md` — Phase 1〜4 セットアップ + ローテーション + トラブルシューティング

### 主要関数

| 関数 | 役割 |
|---|---|
| `getAccessToken_()` | JWT(RS256) で OAuth トークン取得、CacheService で 50分キャッシュ |
| `postBotMessage_(text)` | Bot API v2.0 にテキスト送信 (Bearer 認証) |
| `buildNotificationText_(row)` | Issue #20 仕様の文面組み立て (氏名/期/口数/金額/HP掲載/メッセージ/受付時刻/Sheet URL) |
| `onFormSubmit(e)` | トリガーから呼ばれる handler。失敗時は Logger + ADMIN_EMAIL 宛フォールバック |
| `testNotify()` | 疎通テスト用 (GAS エディタから手動実行) |
| `setupLineWorksProperties(params)` | 6 点 + ADMIN_EMAIL を Properties に一括投入 (必須キー欠落で throw) |
| `installFormSubmitTrigger()` | onFormSubmit トリガーを 1 個だけ登録 (重複防止) |
| `uninstallAllTriggers()` | 緊急停止用 |

### appsscript.json スコープ追加

PR #19 の最小化原則に従い、必要分のみ追加:
- `script.external_request` (LINE WORKS API)
- `script.send_mail` (管理者メールフォールバック)
- `script.scriptapp` (トリガー登録)

## 秘匿情報の取扱い (重要)

本リポジトリは public のため、認証情報 6 点 (Client ID/Secret / Service Account / Private Key / Bot ID / channelId) は:

- **Script Properties 経由のみ**で取り扱い、コードにハードコードしない
- `showProperties()` は `LW_PRIVATE_KEY` / `LW_CLIENT_SECRET` / `DONATIONS_TOKEN` を `***(length=N)` に redact
- 失敗時の管理者メールも認証値を含めない
- PR #21 の secret-scan ハーネスで誤コミットを未然に検知

## TDD トレース

RED → GREEN → REFACTOR
- 文面: 5 件 (Issue #20 仕様 / メッセージなし / 期省略 / メール本文非露出 / その他金額換算)
- JWT: 3 件 (3 セグメント / alg=RS256 / claim 構造)
- 認証: 5 件 (必須 prop 欠落 throw / cache hit / cache miss + endpoint / 4xx throw / 成功時 cache 保存)
- 送信: 2 件 (URL + Bearer header + payload / 4xx throw)
- イベント: 2 件 (成功 / 失敗フォールバック)
- 疎通: 1 件
- マニフェスト: 2 件 (external_request / send_mail スコープ確認)
- Setup: 2 件 (6 点投入 / 欠落 throw)
- 既存 vitest (donation-section / projects-id / check-secrets) 含め全 74 件 pass

## Phase 3〜5 (運用者作業)

1. `clasp push` でコード反映
2. GAS エディタで `setupLineWorksProperties({...})` を実行し Properties 投入
3. `testNotify()` で疎通確認
4. `installFormSubmitTrigger()` でトリガー登録
5. 本番フォームにテスト申込を送信して E2E 確認

詳細は `docs/operations/line-works-notification-setup.md` を参照。

## Test plan

- [x] vitest 全 74 件 pass
- [x] secret-scan 違反 0
- [ ] (運用者) Phase 3〜5 の Phase 4 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
