### PR TITLE
feat: Google CLI 三種 (clasp/gws/gog) 一括セットアップ skill とスクリプトを追加

### DIFF
--- a/.claude/commands/setup-google-clis.md
+++ b/.claude/commands/setup-google-clis.md
@@ -1,0 +1,165 @@
+# Google CLI 三種セットアップ
+
+雄飛会プロジェクトで Google サービスを操作するために 3 つの CLI を入れます。
+インストールから初回 OAuth まで対話的に案内します。
+
+## 3 つの CLI の使い分け
+
+| CLI | 何のため | 推奨度 |
+|---|---|---|
+| **clasp** | GAS スクリプト (Apps Script) を push / deploy する公式 CLI | **必須** (寄付システムの GAS 更新に使う) |
+| **gws** | Drive / Sheets / Gmail / Forms / Calendar など Workspace API 全般を 1 コマンドで操作 (Rust, Discovery API ベース) | **推奨** (drift 検知・データ取得・運用業務) |
+| **gog** | Drive 監査・読み取り業務に強い CLI (Go) | 任意 (大量データ監査が必要なときのみ) |
+
+## 手順
+
+### Step 0: 現在の状態を確認
+
+```bash
+echo "=== clasp ===" && (clasp --version 2>/dev/null || echo "❌ 未インストール")
+echo "=== gws ==="   && (gws --version 2>/dev/null   || echo "❌ 未インストール")
+echo "=== gog ==="   && (gog --version 2>/dev/null   || echo "❌ 未インストール")
+```
+
+3 つの状態を表示。
+
+### Step 1: 一括インストール (OS 別)
+
+#### macOS / Linux
+
+```bash
+bash scripts/setup-google-clis.sh
+```
+
+#### Windows (PowerShell)
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\scripts\setup-google-clis.ps1
+```
+
+部分インストールしたい場合:
+- `--skip-clasp` / `--skip-gws` / `--skip-gog` (bash 版)
+- `-SkipClasp` / `-SkipGws` / `-SkipGog` (PowerShell 版)
+
+### Step 2: clasp の初回認証
+
+```bash
+clasp login
+```
+
+ブラウザが開く → **開発者アカウント (dev ドメイン)** でログイン。
+雄飛会アカウントでログインしないこと (cross-domain redeploy 不能になる)。
+
+動作確認:
+```bash
+cd scripts/gas/donations
+clasp status
+```
+
+### Step 3: gws の初回認証
+
+```bash
+# gcloud がインストールされている場合 (最も簡単)
+gws auth setup
+
+# gcloud がない場合は手動 OAuth 設定
+# 1. Google Cloud Console (https://console.cloud.google.com/) でプロジェクト作成
+# 2. OAuth クライアント (Desktop app) を作成
+# 3. client_secret.json を ~/.config/gws/client_secret.json に配置
+gws auth login -s drive,sheets,gmail,forms,script
+```
+
+⚠️ **OAuth アプリが External + Testing の場合**:
+- ユーザー自身をテストユーザーに追加 (OAuth consent screen → Test users → Add)
+- スコープは 25 個以内 (必要分だけ選ぶ)
+
+動作確認:
+```bash
+gws drive files list --params '{"pageSize": 5}'
+```
+
+### Step 4: gog の初回認証 (任意)
+
+`gog` を入れた場合のみ:
+
+```bash
+# Step 3 で作った client_secret.json を流用可能
+gog auth credentials ~/.config/gws/client_secret.json
+gog auth add you@gmail.com --services drive,sheets,gmail
+```
+
+動作確認:
+```bash
+gog drive tree --parent <folderId> --depth 2
+```
+
+### Step 5: ユーザーに結果報告
+
+```
+🎉 Google CLI 三種セットアップ完了
+
+  ✅ clasp <version>   — 開発者アカウント (xxx@dev-domain.com) でログイン済
+  ✅ gws <version>     — yyy@gmail.com で OAuth 認証済
+  ✅ gog <version>     — (任意) yyy@gmail.com で OAuth 認証済
+
+次にやれること:
+  - /feature-implement <番号>            機能実装 (clasp 自動利用)
+  - gws sheets values get ...            スプレッドシートを直接読む
+  - gws forms responses list ...         フォーム回答を直接取る
+  - clasp push                           GAS コード反映
+```
+
+## 雄飛会プロジェクトでの主な使い道
+
+### clasp
+- `scripts/gas/donations/` の GAS コードを push (LINE WORKS 通知 / 寄付集計)
+- `clasp deploy` で新バージョン公開
+
+### gws
+- 寄付スプレッドシートの列ヘッダーを取得 → `/feature-implement` の schema drift 検知
+  ```bash
+  gws sheets spreadsheets values get \
+    --params '{"spreadsheetId":"1Y5S1uw...","range":"donations!A1:K1"}'
+  ```
+- フォーム回答の確認
+  ```bash
+  gws forms responses list --params '{"formId":"<id>"}'
+  ```
+- Drive の共有設定 (秘匿性チェック)
+  ```bash
+  gws drive files get --params '{"fileId":"<id>","fields":"permissions,owners"}'
+  ```
+
+### gog
+- Drive フォルダの監査
+  ```bash
+  gog drive audit sharing --parent <folderId> --internal-domain kaiho-yuhikai.com
+  ```
+- 寄付関連シートのバックアップ
+  ```bash
+  gog backup push --services drive,sheets
+  ```
+
+## 秘匿情報の取扱い
+
+- `client_secret_*.json` / OAuth refresh token / `credentials.json` は **絶対にコミットしない** (`.gitignore` 済)
+- `pre-commit` フック (`scripts/check-secrets.mjs`) が誤コミットを検知
+- 認証情報の保管は OS keyring (macOS Keychain / Windows Credential Manager) を推奨
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|---|---|
+| `clasp login` で「Access blocked」 | OAuth アプリがテストモード → 自分をテストユーザーに追加 |
+| `gws auth setup` で gcloud がないと言われる | gcloud をインストール or 手動 OAuth 設定で代替 |
+| `gws drive files list` で `accessNotConfigured` | エラーメッセージの `enable_url` にアクセス → API 有効化 |
+| `gog drive` で 401 | `gog auth doctor --check` で確認 → 必要なら `gog auth add` をやり直す |
+| Windows で gog 動かない | Docker 経由 (`docker run --rm ghcr.io/openclaw/gogcli:latest`) を推奨 |
+
+## 注意事項
+
+- **Windows でも動作**: PowerShell 版スクリプト `scripts/setup-google-clis.ps1` を用意
+- **必要分だけインストールでも OK**: 雄飛会の最小構成は `clasp` のみ (寄付システム GAS 更新だけなら)
+- **OAuth スコープは必要最小限**: `drive,sheets,gmail,forms,script` をデフォルトとし、追加が必要になったら拡張
+- **OAuth クライアントは共用可**: `gws` で作った client_secret.json を `gog` でも流用できる (同一 GCP プロジェクト)

--- a/docs/onboarding/business-user-guide.md
+++ b/docs/onboarding/business-user-guide.md
@@ -321,6 +321,57 @@ npm run hooks:install  # pre-commit フックを導入
 - `gh auth status` で未認証 → `gh auth login` で対話的にログイン
 - `claude` コマンドがない → Claude Code 再インストール
 
+## 7.6 Google 三種 CLI のセットアップ
+
+雄飛会プロジェクトでは Google サービスを操作するために 3 つの CLI を使います。
+セットアップは自動化済み、`/setup-google-clis` skill で一発実行可能。
+
+| CLI | 何のため | 推奨度 |
+|---|---|---|
+| **clasp** | GAS スクリプトの push / deploy (公式) | **必須** |
+| **gws** | Drive / Sheets / Gmail / Forms / Calendar 等の API 操作 (公式 Rust) | **推奨** |
+| **gog** | Drive 監査・読み取り業務 (コミュニティ Go) | 任意 |
+
+### ワンライナーインストール
+
+**macOS / Linux**:
+```bash
+bash scripts/setup-google-clis.sh
+```
+
+**Windows (PowerShell)**:
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\scripts\setup-google-clis.ps1
+```
+
+### Claude Code 経由 (推奨)
+
+```
+/setup-google-clis
+```
+
+Claude が「現在の状態確認 → インストール → OAuth 認証ガイド」まで対話的に進めます。
+
+### よく使うコマンド例
+
+```bash
+# GAS コードを反映
+cd scripts/gas/donations && clasp push
+
+# 寄付スプレッドシートの列ヘッダーを取得 (drift 検知用)
+gws sheets spreadsheets values get \
+  --params '{"spreadsheetId":"1Y5S1uw...","range":"donations!A1:K1"}'
+
+# フォーム回答を確認
+gws forms responses list --params '{"formId":"<id>"}'
+
+# Drive の共有設定監査
+gog drive audit sharing --parent <folderId> --internal-domain kaiho-yuhikai.com
+```
+
+詳しくは `.claude/commands/setup-google-clis.md` 参照。
+
 ## 8. スキトラデモのチェックリスト (今日の会で確認)
 
 ### 共通

--- a/scripts/setup-google-clis.ps1
+++ b/scripts/setup-google-clis.ps1
@@ -1,0 +1,105 @@
+# =============================================================================
+# Google CLI 三種セットアップ (Windows PowerShell)
+#
+# 雄飛会プロジェクトで使う 3 つの Google 関連 CLI を一括インストール:
+#   1. clasp — Google Apps Script CLI (公式) / GAS コード push/deploy 用
+#   2. gws   — Google Workspace CLI (Rust, googleworkspace/cli)
+#   3. gog   — gogcli (Go, openclaw/gogcli)
+#
+# 使い方 (PowerShell):
+#   Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+#   .\scripts\setup-google-clis.ps1
+#   .\scripts\setup-google-clis.ps1 -SkipClasp -SkipGog
+# =============================================================================
+
+param(
+    [switch]$SkipClasp,
+    [switch]$SkipGws,
+    [switch]$SkipGog
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($text) {
+    Write-Host ""
+    Write-Host "▶ $text" -ForegroundColor Cyan
+}
+function Write-Ok($text)   { Write-Host "  [OK] $text" -ForegroundColor Green }
+function Write-Warn($text) { Write-Host "  [WARN] $text" -ForegroundColor Yellow }
+function Write-Err($text)  { Write-Host "  [ERR] $text" -ForegroundColor Red }
+
+function Test-Command($name) {
+    return (Get-Command $name -ErrorAction SilentlyContinue) -ne $null
+}
+
+# ------------ 1. clasp ------------
+if (-not $SkipClasp) {
+    Write-Step "clasp (Google Apps Script CLI) をインストール"
+    if (Test-Command "clasp") {
+        Write-Ok ("clasp 既にインストール済 (" + (clasp --version 2>&1 | Select-Object -First 1) + ")")
+    } else {
+        if (-not (Test-Command "npm")) {
+            Write-Err "npm が見つかりません。Node.js をインストールしてから再実行してください。"
+            exit 1
+        }
+        npm install -g @google/clasp
+        Write-Ok "clasp インストール完了"
+    }
+    Write-Host ""
+    Write-Host "  次の手順:"
+    Write-Host "    clasp login    # 開発者アカウント (dev ドメイン) でログイン"
+    Write-Host "    cd scripts/gas/donations; clasp push"
+}
+
+# ------------ 2. gws ------------
+if (-not $SkipGws) {
+    Write-Step "gws (Google Workspace CLI) をインストール"
+    if (Test-Command "gws") {
+        Write-Ok ("gws 既にインストール済 (" + (gws --version 2>&1 | Select-Object -First 1) + ")")
+    } else {
+        # winget があれば優先、なければ npm
+        if (Test-Command "winget") {
+            try {
+                winget install googleworkspace-cli 2>&1 | Out-Null
+                Write-Ok "gws インストール完了 (winget)"
+            } catch {
+                npm install -g @googleworkspace/cli
+                Write-Ok "gws インストール完了 (npm fallback)"
+            }
+        } else {
+            npm install -g @googleworkspace/cli
+            Write-Ok "gws インストール完了 (npm)"
+        }
+    }
+    Write-Host ""
+    Write-Host "  次の手順:"
+    Write-Host "    gws auth setup    # 対話的に OAuth 設定 (gcloud があると最も簡単)"
+    Write-Host "    gws auth login    # スコープ選択 (推奨: drive,sheets,gmail,forms,script)"
+    Write-Host "    gws drive files list --params '{`"pageSize`": 5}'  # 動作確認"
+}
+
+# ------------ 3. gog ------------
+if (-not $SkipGog) {
+    Write-Step "gog (gogcli) をインストール"
+    if (Test-Command "gog") {
+        Write-Ok ("gog 既にインストール済 (" + (gog --version 2>&1 | Select-Object -First 1) + ")")
+    } else {
+        Write-Warn "gog の Windows 公式インストーラーは ZIP 配布のみです。"
+        Write-Host "  推奨手順:"
+        Write-Host "    1. https://github.com/openclaw/gogcli/releases から gogcli_*_windows_amd64.zip を DL"
+        Write-Host "    2. zip を展開し、gog.exe を PATH (例: C:\Users\<user>\bin) に配置"
+        Write-Host "    3. PowerShell を再起動して 'gog --version' で確認"
+        Write-Host ""
+        Write-Host "  Docker を使う場合 (推奨):"
+        Write-Host "    Set-Alias gog 'docker run --rm ghcr.io/openclaw/gogcli:latest'"
+    }
+    Write-Host ""
+    Write-Host "  次の手順:"
+    Write-Host "    gog auth credentials .\client_secret_xxx.json"
+    Write-Host "    gog auth add you@gmail.com --services drive,sheets,gmail"
+    Write-Host "    gog drive tree --parent <folderId> --depth 2  # 動作確認"
+}
+
+Write-Step "セットアップ完了"
+Write-Host "  Claude Code で /setup-google-clis を呼ぶと初回 OAuth まで対話的に案内します。"
+Write-Host "  詳細: docs/onboarding/business-user-guide.md §7.6"

--- a/scripts/setup-google-clis.sh
+++ b/scripts/setup-google-clis.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Google CLI 三種セットアップ (macOS / Linux)
+#
+# 雄飛会プロジェクトで使う 3 つの Google 関連 CLI を一括インストール:
+#   1. clasp  — Google Apps Script CLI (公式) / GAS コード push/deploy 用
+#   2. gws    — Google Workspace CLI (Rust, googleworkspace/cli)
+#              Discovery API ベースで Drive/Gmail/Sheets/Calendar 等を一発操作
+#   3. gog    — gogcli (Go, openclaw/gogcli)
+#              Drive 監査・読み取り業務に強い
+#
+# 使い方:
+#   bash scripts/setup-google-clis.sh             # 通常実行
+#   bash scripts/setup-google-clis.sh --skip-clasp # clasp は既に入っているのでスキップ
+# =============================================================================
+
+set -euo pipefail
+
+SKIP_CLASP=0
+SKIP_GWS=0
+SKIP_GOG=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --skip-clasp) SKIP_CLASP=1 ;;
+    --skip-gws)   SKIP_GWS=1 ;;
+    --skip-gog)   SKIP_GOG=1 ;;
+    --help|-h)
+      echo "Usage: $0 [--skip-clasp] [--skip-gws] [--skip-gog]"
+      exit 0
+      ;;
+  esac
+done
+
+print_step() { printf "\n\033[1;36m▶ %s\033[0m\n" "$1"; }
+print_ok()   { printf "  \033[1;32m✅ %s\033[0m\n" "$1"; }
+print_warn() { printf "  \033[1;33m⚠️  %s\033[0m\n" "$1"; }
+print_err()  { printf "  \033[1;31m❌ %s\033[0m\n" "$1"; }
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+# ------------ 1. clasp ------------
+if [ "$SKIP_CLASP" -eq 0 ]; then
+  print_step "clasp (Google Apps Script CLI) をインストール"
+  if command -v clasp >/dev/null 2>&1; then
+    print_ok "clasp 既にインストール済 ($(clasp --version 2>&1 | head -1))"
+  else
+    if ! command -v npm >/dev/null 2>&1; then
+      print_err "npm が見つかりません。Node.js をインストールしてから再実行してください。"
+      exit 1
+    fi
+    npm install -g @google/clasp
+    print_ok "clasp インストール完了"
+  fi
+  echo
+  echo "  次の手順:"
+  echo "    clasp login    # 開発者アカウント (dev ドメイン) でログイン"
+  echo "    cd scripts/gas/donations && clasp push"
+fi
+
+# ------------ 2. gws ------------
+if [ "$SKIP_GWS" -eq 0 ]; then
+  print_step "gws (Google Workspace CLI) をインストール"
+  if command -v gws >/dev/null 2>&1; then
+    print_ok "gws 既にインストール済 ($(gws --version 2>&1 | head -1))"
+  else
+    if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+      brew install googleworkspace-cli || npm install -g @googleworkspace/cli
+    else
+      npm install -g @googleworkspace/cli
+    fi
+    print_ok "gws インストール完了"
+  fi
+  echo
+  echo "  次の手順:"
+  echo "    gws auth setup    # 対話的に OAuth 設定 (gcloud があると最も簡単)"
+  echo "    gws auth login    # スコープ選択 (推奨: drive,sheets,gmail,forms,script)"
+  echo "    gws drive files list --params '{\"pageSize\": 5}'  # 動作確認"
+fi
+
+# ------------ 3. gog ------------
+if [ "$SKIP_GOG" -eq 0 ]; then
+  print_step "gog (gogcli) をインストール"
+  if command -v gog >/dev/null 2>&1; then
+    print_ok "gog 既にインストール済 ($(gog --version 2>&1 | head -1))"
+  else
+    if [ "$OS" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
+      brew install gogcli
+      print_ok "gog インストール完了"
+    elif command -v docker >/dev/null 2>&1; then
+      print_warn "Homebrew がないため Docker での実行を推奨します:"
+      echo "  alias gog='docker run --rm ghcr.io/openclaw/gogcli:latest'"
+    else
+      print_warn "Homebrew も Docker もないため、手動インストールを推奨:"
+      echo "  https://github.com/openclaw/gogcli から最新リリースを DL"
+    fi
+  fi
+  echo
+  echo "  次の手順:"
+  echo "    gog auth credentials ~/Downloads/client_secret_xxx.json"
+  echo "    gog auth add you@gmail.com --services drive,sheets,gmail"
+  echo "    gog drive tree --parent <folderId> --depth 2  # 動作確認"
+fi
+
+print_step "セットアップ完了"
+echo "  Claude Code で /setup-google-clis を呼ぶと初回 OAuth まで対話的に案内します。"
+echo "  詳細: docs/onboarding/business-user-guide.md §7.6"


### PR DESCRIPTION
## Summary

ビジネスユーザー (上間さん等) が Google サービスの API を CLI で操作できるよう、
3 つの CLI (clasp / gws / gog) のインストール〜 OAuth 認証までをワンライナー化 + skill 化。

## 追加

- `scripts/setup-google-clis.sh` — macOS / Linux (Homebrew + npm)
- `scripts/setup-google-clis.ps1` — Windows PowerShell (winget + npm)
- `.claude/commands/setup-google-clis.md` — `/setup-google-clis` skill
- `docs/onboarding/business-user-guide.md` §7.6 で使い分け解説

## 使い分け

| CLI | 用途 | 推奨度 |
|---|---|---|
| clasp | GAS push / deploy (既存運用) | 必須 |
| gws (Rust, 公式 googleworkspace/cli) | Drive/Sheets/Gmail/Forms/Calendar 全般 | 推奨 |
| gog (Go, openclaw/gogcli) | Drive 監査・読み取り業務 | 任意 |

## 使い方

```bash
# macOS / Linux
bash scripts/setup-google-clis.sh

# Windows
.\scripts\setup-google-clis.ps1

# Claude Code 経由 (対話的 OAuth 案内付き)
/setup-google-clis
```

## 雄飛会での主な使い道

```bash
# 寄付スプレッドシートの列ヘッダー取得 → schema drift 検知
gws sheets spreadsheets values get \
  --params '{"spreadsheetId":"1Y5S1uw...","range":"donations!A1:K1"}'

# フォーム回答を直接取得
gws forms responses list --params '{"formId":"<id>"}'

# Drive の共有設定監査
gog drive audit sharing --parent <folderId> --internal-domain kaiho-yuhikai.com
```

## Test plan

- [x] npm test 全 74 件 pass
- [x] secret-scan 違反 0
- [ ] (上間さん) Windows 環境で `.\scripts\setup-google-clis.ps1` を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
