### PR TITLE
feat: ハーネスと skill を大幅簡略化 (STEP 5→4, gws を必須からオプションへ)

### DIFF
--- a/.claude/commands/setup-google-clis.md
+++ b/.claude/commands/setup-google-clis.md
@@ -1,165 +1,123 @@
-# Google CLI 三種セットアップ
+# Google CLI gws / gog のセットアップ (オプション)
 
-雄飛会プロジェクトで Google サービスを操作するために 3 つの CLI を入れます。
-インストールから初回 OAuth まで対話的に案内します。
+雄飛会の **最小運用には不要** ですが、Drive / Sheets / Forms / Gmail などを直接 API で叩きたい開発者向けの追加 CLI セットアップです。
 
-## 3 つの CLI の使い分け
+> 💡 **基本は `/setup` のみで OK**。本 skill は「Sheet 列ヘッダーを直接読みたい」「フォーム回答を一括ダウンロードしたい」等のニーズが出てから実行してください。
 
-| CLI | 何のため | 推奨度 |
+## 何が入るか
+
+| CLI | 用途 | 認証の手間 |
 |---|---|---|
-| **clasp** | GAS スクリプト (Apps Script) を push / deploy する公式 CLI | **必須** (寄付システムの GAS 更新に使う) |
-| **gws** | Drive / Sheets / Gmail / Forms / Calendar など Workspace API 全般を 1 コマンドで操作 (Rust, Discovery API ベース) | **推奨** (drift 検知・データ取得・運用業務) |
-| **gog** | Drive 監査・読み取り業務に強い CLI (Go) | 任意 (大量データ監査が必要なときのみ) |
+| **gws** (Rust, 公式) | Drive / Sheets / Gmail / Forms / Calendar 全般 | 中 (GCP プロジェクトに OAuth クライアント作成が必要) |
+| **gog** (Go, OSS) | Drive 監査・読み取り業務 | 中 |
+
+clasp は `/setup` ですでに入っているのでここでは扱いません。
 
 ## 手順
 
-### Step 0: 現在の状態を確認
+### Step 1: 現在の状態
 
 ```bash
-echo "=== clasp ===" && (clasp --version 2>/dev/null || echo "❌ 未インストール")
-echo "=== gws ==="   && (gws --version 2>/dev/null   || echo "❌ 未インストール")
-echo "=== gog ==="   && (gog --version 2>/dev/null   || echo "❌ 未インストール")
+echo "=== gws ===" && (gws --version 2>/dev/null || echo "❌ 未インストール")
+echo "=== gog ===" && (gog --version 2>/dev/null || echo "❌ 未インストール")
+echo "=== gcloud ===" && (gcloud --version 2>/dev/null | head -1 || echo "❌ 未インストール (gws auth setup が遅くなる)")
 ```
 
-3 つの状態を表示。
+### Step 2: インストール
 
-### Step 1: 一括インストール (OS 別)
-
-#### macOS / Linux
+#### macOS
 
 ```bash
-bash scripts/setup-google-clis.sh
+brew install googleworkspace-cli  # gws
+brew install gogcli                # gog
 ```
 
-#### Windows (PowerShell)
+または npm 経由 (cross-platform):
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+#### Windows
 
 ```powershell
-Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
-.\scripts\setup-google-clis.ps1
+.\scripts\setup-google-clis.ps1 -SkipClasp  # clasp は /setup で済んでいる
 ```
 
-部分インストールしたい場合:
-- `--skip-clasp` / `--skip-gws` / `--skip-gog` (bash 版)
-- `-SkipClasp` / `-SkipGws` / `-SkipGog` (PowerShell 版)
+### Step 3: gws 認証 — 2 パターン
 
-### Step 2: clasp の初回認証
+#### パターン A: gcloud が入っていて、雄飛会専用 GCP プロジェクトがある場合
 
 ```bash
-clasp login
-```
-
-ブラウザが開く → **開発者アカウント (dev ドメイン)** でログイン。
-雄飛会アカウントでログインしないこと (cross-domain redeploy 不能になる)。
-
-動作確認:
-```bash
-cd scripts/gas/donations
-clasp status
-```
-
-### Step 3: gws の初回認証
-
-```bash
-# gcloud がインストールされている場合 (最も簡単)
+gcloud config set project <kaiho-yuuhikai 専用プロジェクト>
 gws auth setup
-
-# gcloud がない場合は手動 OAuth 設定
-# 1. Google Cloud Console (https://console.cloud.google.com/) でプロジェクト作成
-# 2. OAuth クライアント (Desktop app) を作成
-# 3. client_secret.json を ~/.config/gws/client_secret.json に配置
-gws auth login -s drive,sheets,gmail,forms,script
 ```
 
-⚠️ **OAuth アプリが External + Testing の場合**:
-- ユーザー自身をテストユーザーに追加 (OAuth consent screen → Test users → Add)
-- スコープは 25 個以内 (必要分だけ選ぶ)
+→ ブラウザで OAuth 完了 → `gws drive files list --params '{"pageSize": 3}'` で動作確認。
 
-動作確認:
+#### パターン B: GCP プロジェクトを新規作成する場合 (10 分作業)
+
+OAuth クライアントを手動で作る必要があります:
+
+1. <https://console.cloud.google.com/> でプロジェクト「kaiho-yuuhikai-cli」を作成
+2. **OAuth consent screen** を設定:
+   - User Type: External (個人 Google) or Internal (Workspace)
+   - App name: kaiho-yuuhikai-cli
+   - Support email: 自分の Google アカウント
+3. **OAuth client ID** を作成:
+   - Application type: **Desktop app**
+   - Name: gws-cli
+4. 表示された `client_secret_xxx.json` を以下に保存:
+   ```bash
+   ~/.config/gws/client_secret.json
+   ```
+5. ブラウザで OAuth 完了:
+   ```bash
+   gws auth login -s drive,sheets,gmail,forms,script
+   ```
+
+⚠️ External + Testing モードの場合は自分をテストユーザーに追加 (consent screen → Test users → Add)
+
+### Step 4: gog 認証 (任意)
+
+gws と同じ `client_secret.json` を流用:
+
 ```bash
-gws drive files list --params '{"pageSize": 5}'
-```
-
-### Step 4: gog の初回認証 (任意)
-
-`gog` を入れた場合のみ:
-
-```bash
-# Step 3 で作った client_secret.json を流用可能
 gog auth credentials ~/.config/gws/client_secret.json
 gog auth add <your-email> --services drive,sheets,gmail
 ```
 
 動作確認:
+
 ```bash
-gog drive tree --parent <folderId> --depth 2
+gog drive ls --max 3
 ```
 
-### Step 5: ユーザーに結果報告
+### Step 5: 雄飛会プロジェクトでの主な使い道
 
+```bash
+# 寄付スプレッドシートの列ヘッダー取得 → schema drift 検知
+gws sheets spreadsheets values get \
+  --params '{"spreadsheetId":"1Y5S1uw...","range":"donations!A1:K1"}'
+
+# フォーム回答を直接取得
+gws forms responses list --params '{"formId":"<id>"}'
+
+# Drive 共有設定の監査
+gog drive audit sharing --parent <folderId> --internal-domain kaiho-yuhikai.com
 ```
-🎉 Google CLI 三種セットアップ完了
-
-  ✅ clasp <version>   — 開発者アカウント (<dev-account>) でログイン済
-  ✅ gws <version>     — <user-email> で OAuth 認証済
-  ✅ gog <version>     — (任意) <user-email> で OAuth 認証済
-
-次にやれること:
-  - /feature-implement <番号>            機能実装 (clasp 自動利用)
-  - gws sheets values get ...            スプレッドシートを直接読む
-  - gws forms responses list ...         フォーム回答を直接取る
-  - clasp push                           GAS コード反映
-```
-
-## 雄飛会プロジェクトでの主な使い道
-
-### clasp
-- `scripts/gas/donations/` の GAS コードを push (LINE WORKS 通知 / 寄付集計)
-- `clasp deploy` で新バージョン公開
-
-### gws
-- 寄付スプレッドシートの列ヘッダーを取得 → `/feature-implement` の schema drift 検知
-  ```bash
-  gws sheets spreadsheets values get \
-    --params '{"spreadsheetId":"1Y5S1uw...","range":"donations!A1:K1"}'
-  ```
-- フォーム回答の確認
-  ```bash
-  gws forms responses list --params '{"formId":"<id>"}'
-  ```
-- Drive の共有設定 (秘匿性チェック)
-  ```bash
-  gws drive files get --params '{"fileId":"<id>","fields":"permissions,owners"}'
-  ```
-
-### gog
-- Drive フォルダの監査
-  ```bash
-  gog drive audit sharing --parent <folderId> --internal-domain kaiho-yuhikai.com
-  ```
-- 寄付関連シートのバックアップ
-  ```bash
-  gog backup push --services drive,sheets
-  ```
-
-## 秘匿情報の取扱い
-
-- `client_secret_*.json` / OAuth refresh token / `credentials.json` は **絶対にコミットしない** (`.gitignore` 済)
-- `pre-commit` フック (`scripts/check-secrets.mjs`) が誤コミットを検知
-- 認証情報の保管は OS keyring (macOS Keychain / Windows Credential Manager) を推奨
 
 ## トラブルシューティング
 
 | 症状 | 対処 |
 |---|---|
-| `clasp login` で「Access blocked」 | OAuth アプリがテストモード → 自分をテストユーザーに追加 |
-| `gws auth setup` で gcloud がないと言われる | gcloud をインストール or 手動 OAuth 設定で代替 |
-| `gws drive files list` で `accessNotConfigured` | エラーメッセージの `enable_url` にアクセス → API 有効化 |
-| `gog drive` で 401 | `gog auth doctor --check` で確認 → 必要なら `gog auth add` をやり直す |
-| Windows で gog 動かない | Docker 経由 (`docker run --rm ghcr.io/openclaw/gogcli:latest`) を推奨 |
+| `gws auth setup` で「OAuth client creation requires manual setup」 | Step 3 パターン B の手動 OAuth クライアント作成へ |
+| `gws auth login` で 401/403 | スコープが OAuth consent screen に登録されていない / 自分がテストユーザー未登録 |
+| `gog auth doctor --check` で 401 | `gog auth add <email>` を再実行 |
+| 既存 `~/.config/gws/client_secret.json` が壊れている | 削除して再ダウンロード or `gws auth setup` 再実行 |
 
 ## 注意事項
 
-- **Windows でも動作**: PowerShell 版スクリプト `scripts/setup-google-clis.ps1` を用意
-- **必要分だけインストールでも OK**: 雄飛会の最小構成は `clasp` のみ (寄付システム GAS 更新だけなら)
-- **OAuth スコープは必要最小限**: `drive,sheets,gmail,forms,script` をデフォルトとし、追加が必要になったら拡張
-- **OAuth クライアントは共用可**: `gws` で作った client_secret.json を `gog` でも流用できる (同一 GCP プロジェクト)
+- **必要に応じてだけ**: 雄飛会の通常運用 (`/site-update` / `/feature-implement` / `/lineworks-deploy`) は `/setup` の clasp だけで完結
+- **GCP プロジェクトは雄飛会専用に**: 他案件 (GScale 業務等) の GCP プロジェクトと混ざらないように
+- **client_secret.json は絶対にコミットしない**: `.gitignore` 済 / pre-commit hook が検知

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,114 +1,114 @@
-# 開発環境セットアップ
+# 開発環境セットアップ (一発)
 
-非エンジニアのユーザーが開発環境を構築するためのガイド付きセットアップを実行します。
-各ツールのインストール状況を確認し、不足しているものを自動でインストールします。
+このプロジェクトの開発環境を一括セットアップします。
+ビジネスユーザーが何も覚えずに `/setup` 1 回で完了するよう設計されています。
+
+## やること
+
+1. OS 判定 (macOS / Linux / Windows)
+2. 必要ツールのインストール:
+   - Node.js (v20+) / npm
+   - Git / GitHub CLI (`gh`)
+   - Homebrew (macOS) / winget (Windows)
+   - **clasp** (Google Apps Script CLI、雄飛会必須)
+3. プロジェクト依存パッケージ (`npm install`)
+4. pre-commit secret-scan フック導入 (`npm run hooks:install`)
+5. GitHub 認証確認 (`gh auth status`)
+6. clasp 認証ガイド (ブラウザを開く)
 
 ## 手順
 
-### Step 1: 現在の環境を診断
+### Step 1: OS 判定 + 一括スクリプト実行
 
-以下のコマンドを実行し、各ツールのインストール状況を確認してください:
+ユーザー OS に応じて以下のいずれかを実行:
 
-```bash
-echo "=== OS ===" && uname -s && sw_vers 2>/dev/null || cat /etc/os-release 2>/dev/null
-echo "=== Homebrew ===" && brew --version 2>/dev/null || echo "未インストール"
-echo "=== Node.js ===" && node --version 2>/dev/null || echo "未インストール"
-echo "=== npm ===" && npm --version 2>/dev/null || echo "未インストール"
-echo "=== GitHub CLI ===" && gh --version 2>/dev/null || echo "未インストール"
-echo "=== Claude Code ===" && claude --version 2>/dev/null || echo "未インストール"
-echo "=== Gemini CLI ===" && gemini --version 2>/dev/null || echo "未インストール"
-echo "=== Codex CLI ===" && codex --version 2>/dev/null || echo "未インストール"
-```
+#### macOS / Linux
 
-結果を日本語で分かりやすく一覧表示してください:
-- ✅ インストール済み（バージョン付き）
-- ❌ 未インストール
-
-### Step 2: 不足ツールのインストール
-
-未インストールのツールがあれば、以下の順番で1つずつインストールしてください。
-**各ステップごとにユーザーに「インストールしてよいですか？」と確認してから実行すること。**
-
-#### 2-1: Homebrew（macOS のみ）
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-Apple Silicon Mac の場合は追加で:
-```bash
-eval "$(/opt/homebrew/bin/brew shellenv)"
-echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
-```
-
-#### 2-2: Node.js（v20以上）
-```bash
-brew install node@22
-```
-
-#### 2-3: GitHub CLI
-```bash
-brew install gh
-```
-
-#### 2-4: Claude Code
-```bash
-curl -fsSL https://claude.ai/install.sh | bash
-```
-
-#### 2-5: Gemini CLI
-```bash
-npm install -g @google/gemini-cli
-```
-
-#### 2-6: Codex CLI
-```bash
-npm install -g @openai/codex
-```
-
-### Step 3: プロジェクト依存パッケージ
-
-`node_modules` が存在しない、または `package-lock.json` より古い場合:
-```bash
-npm install
-```
-
-### Step 4: GitHub 認証
-
-GitHub CLI の認証状態を確認:
-```bash
-gh auth status
-```
-
-未認証の場合、ユーザーに以下を案内:
-- 「GitHub にログインする必要があります。今からブラウザが開きますので、GitHub アカウントでログインしてください」
-- ユーザーの承認を得てから実行:
-```bash
-gh auth login
-```
-
-### Step 5: セットアップ完了の確認
-
-全ツールの状態を再確認し、結果を表示してください。
-
-全て ✅ であれば、以下を案内:
-
-```
-セットアップが完了しました！
-
-サイトを更新するには:
-  /project:site-update 変更したい内容を入力
-
-プレビューするには:
-  /project:site-preview
-
-公開に反映するには:
-  /project:site-publish
-```
-
-❌ が残っている場合は、問題の原因と解決方法を案内してください。
-
-## 一括セットアップスクリプト
-
-対話形式ではなく一括で実行したい場合は、以下を案内:
 ```bash
 bash scripts/setup.sh
 ```
+
+→ Homebrew + Node + gh + Claude Code + Gemini CLI + Codex CLI を入れる。
+続けて clasp もインストール:
+
+```bash
+npm install -g @google/clasp
+```
+
+#### Windows (PowerShell)
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\scripts\setup.ps1
+npm install -g @google/clasp
+```
+
+### Step 2: プロジェクト依存
+
+```bash
+npm install
+npm run hooks:install
+```
+
+### Step 3: GitHub 認証
+
+```bash
+gh auth status 2>&1 | grep "Logged in" | head -3 || gh auth login
+```
+
+未認証なら `gh auth login` をユーザーに案内 (ブラウザが開く)。
+
+### Step 4: clasp 認証
+
+```bash
+clasp login --status 2>&1 | head -3 || clasp login
+```
+
+ブラウザが開くので **GAS プロジェクトを所有する開発者ドメインのアカウント** でログイン。
+雄飛会アカウント (`office@kaiho-yuhikai.com`) ではログインしない (cross-domain redeploy 不能になる)。
+
+### Step 5: 完了レポート
+
+```
+🎉 環境セットアップ完了
+
+  ✅ Node.js / npm
+  ✅ Git / GitHub CLI (認証済)
+  ✅ Claude Code
+  ✅ clasp (開発者アカウントでログイン済)
+  ✅ プロジェクト依存パッケージ
+  ✅ pre-commit secret-scan フック
+
+これで使える skill:
+  /system-tour          既存システムを画面で見る
+  /site-update          サイトを変更する
+  /feature-implement N  機能を実装する
+  /lineworks-deploy     LINE WORKS Bot を稼働する
+
+困ったら /setup-check で再診断。
+```
+
+## オプション: gws / gog も入れたい場合
+
+雄飛会の最小運用には不要ですが、Sheet / Form / Drive を直接 API で叩きたい開発者向け:
+
+```
+/setup-google-clis
+```
+
+を別途実行。GCP プロジェクトでの OAuth クライアント手動作成が必要なため、本 skill には含めない。
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|---|---|
+| `gh auth status` で未認証 | `gh auth login` を実行 (ブラウザで承認) |
+| `clasp login` で「Access blocked」 | OAuth アプリがテストモード → 自分をテストユーザーに追加 |
+| `npm install` が遅い | プロキシ設定 / DNS / `npm config get registry` を確認 |
+| Windows で `setup.ps1` が止まる | `Set-ExecutionPolicy` のスコープ設定が必要 |
+
+## 注意事項
+
+- **対話的 OAuth は手動承認が必要**: ブラウザが開いたらユーザーが手動でログインする
+- **clasp は雄飛会の必須ツール**: GAS の push / deploy に使う
+- **gws / gog はオプション**: 必要になったら `/setup-google-clis` で別途

--- a/docs/onboarding/business-user-guide.md
+++ b/docs/onboarding/business-user-guide.md
@@ -1,25 +1,13 @@
 # 雄飛会公式サイト 開発・運用ハンドブック
 
-> このドキュメントは **Claude Code の skill (`/コマンド`) だけで全工程が完結する** よう設計されています。
-> ターミナルで直接コマンドを打つ必要はありません。
-
-**対象**: 開邦雄飛会公式サイトの開発・運用を引き継ぐビジネスチームメンバー (上間さん想定)
-**所要時間**: 約 2 時間 (デモ会の中で完走可能)
+> **Claude Code の `/コマンド` だけで全工程が完結します。** ターミナルで直接コマンドを打つ必要はありません。
+>
+> **対象**: 雄飛会公式サイトの開発・運用を引き継ぐビジネスチーム (上間さん想定)
+> **所要時間**: 約 2 時間 (デモ会で完走可能)
 
 ---
 
-## 0. これから何をするか (Bird's Eye View)
-
-このシステムは以下の 4 つの世界をつなげています:
-
-| 世界 | 何の役割 | 誰が触る |
-|---|---|---|
-| 📝 **Google Workspace** | フォーム入力・データ保管・承認 | ビジネスチーム (上間 / 屋良) |
-| ⚙️ **Apps Script (GAS)** | 集計・通知ロジック | 開発者 (神谷) |
-| 🚀 **GitHub** | コード管理・自動デプロイ | 開発者 + ビジネスチーム |
-| 🌐 **Web サイト** | 公開 HP <https://kaiho-yuuhikai.jp/> | 訪問者 |
-
-### 全体アーキテクチャ
+## 0. 全体像 (Bird's Eye View)
 
 ```mermaid
 flowchart TB
@@ -71,245 +59,140 @@ flowchart TB
     class Bot,Room messaging
 ```
 
-> 💡 **大事な原則**: 全部 **無料枠** で月額 ¥0 で運用しています。
+| 世界 | 役割 | 誰が触る |
+|---|---|---|
+| 📝 Google Workspace | フォーム + データ + 承認 | ビジネス (上間 / 屋良) |
+| ⚙️ Apps Script | 集計・通知ロジック | 開発者 (神谷) |
+| 🚀 GitHub | コード + 自動デプロイ | 開発者 + ビジネス |
+| 🌐 Web | <https://kaiho-yuuhikai.jp/> | 訪問者 |
+
+すべて無料枠で月額 ¥0 で運用。
 
 ---
 
-# 📚 STEP 別 手順書 (Claude Code skill だけで進む)
+# 📚 4 つの STEP で完了
 
-> Claude Code を起動して、各 STEP の `/コマンド` を **順番に上から下に** 打てばすべて完了します。
-> ターミナルで直接 git / npm / clasp 等を打つ必要はありません。
-
----
-
-## ▶️ 事前準備: Claude Code を起動
-
-ターミナル (Windows なら PowerShell or Git Bash) で:
-
-```bash
-claude
-```
-
-これだけ。あとはすべて Claude Code の中の `/コマンド` で進めます。
+> Claude Code を `claude` で起動 → 以下の `/コマンド` を上から順に実行するだけ。
 
 ---
 
 ## STEP 1: 環境セットアップ (15 分)
 
-> **目的**: 必要なツールを全部入れる
-> **使う skill**: `/setup` → `/setup-google-clis` → `/setup-check`
-
-### 1.1 全ツール一括インストール
-
 ```
 /setup
 ```
 
-これだけで以下が全部入ります:
-- Node.js / Git / GitHub CLI / Claude Code
-- Homebrew (Mac) / winget (Windows)
-- プロジェクトの依存パッケージ (`npm install`)
+これ 1 つで全部入る:
+- Node.js / Git / GitHub CLI / Claude Code / **clasp**
+- プロジェクト依存パッケージ
 - pre-commit secret-scan フック
+- GitHub 認証 + clasp 認証 (ブラウザ起動)
 
-Claude が「これをインストールしてよいですか?」と聞いてくれるので OK と答えるだけ。
-
-### 1.2 Google CLI 三種セットアップ
-
-```
-/setup-google-clis
-```
-
-これで `clasp` / `gws` / `gog` が一括で入ります。
-OAuth 認証も対話的に案内されます。
-
-### 1.3 環境チェック
+確認:
 
 ```
 /setup-check
 ```
 
-→ 全項目が ✅ なら STEP 2 へ。❌ があれば項目に従って修正。
+→ 全項目 ✅ なら次へ。
+
+> 💡 `gws` / `gog` (Sheets/Drive を直接 API で叩く CLI) は最小運用には不要。必要になったら `/setup-google-clis` で別途追加可。
 
 ---
 
-## STEP 2: 既存システムを見る (15 分)
-
-> **目的**: 5 つの構成要素 (Form / Sheet / GAS / Actions / Pages) を順に画面確認
-> **使う skill**: `/system-tour`
+## STEP 2: 既存システムを画面で見る (15 分)
 
 ```
 /system-tour
 ```
 
-Claude が以下を順に案内 + ブラウザを開いてくれます:
-- ① Google フォーム
-- ② スプレッドシート (I 列のプルダウンを試す)
-- ③ GitHub Actions (cron + 手動実行)
-- ④ GitHub Pages (公開サイト)
-- ⑤ Apps Script エディタ
+Claude が 5 つの画面を順に開いて案内:
+1. Google フォーム (入力)
+2. スプレッドシート (承認列の操作)
+3. GitHub Actions (自動デプロイ履歴)
+4. GitHub Pages (公開サイト)
+5. Apps Script エディタ (集計・通知ロジック)
 
-各画面で「次へ」と入力すると次に進みます。
-
----
-
-## STEP 3: サイトの簡単な変更を試す (15 分)
-
-> **目的**: テキスト・画像の差し替えを Claude Code で行う体験
-> **使う skill**: `/site-preview` → `/site-update` → `/site-publish`
-
-### 3.1 ローカルプレビュー
-
-```
-/site-preview
-```
-
-→ ブラウザで <http://localhost:3000/official-site/> が開く
-
-### 3.2 変更を依頼
-
-```
-/site-update トップページのキャッチコピーを「次の50年へ」に変更したい
-```
-
-Claude が:
-- 該当ファイルを特定
-- 修正 + 自動テスト
-- プレビュー確認を促す
-
-### 3.3 本番反映
-
-```
-/site-publish
-```
-
-→ 数分後に <https://kaiho-yuuhikai.jp/> で確認 (Ctrl+Shift+R で再読込)
+各画面で「次へ」と入力すると進む。
 
 ---
 
-## STEP 4: 機能追加を試す (30 分)
+## STEP 3: 変更・機能追加を試す (45 分)
 
-> **目的**: 「新機能 Issue 起票 → 実装 → マージ」を Claude Code だけで完結する体験
-> **使う skill**: `/issue-list` → `/feature-add` → `/feature-implement` → `/feature-review-merge`
-
-### 4.1 現在の課題を見る
+### 3-A. 小さな変更 (文言・画像)
 
 ```
-/issue-list
+/site-preview                                   # ローカルプレビュー起動
+/site-update こうしてほしい                      # Claude が修正 + テスト
+/site-publish                                   # 本番反映
 ```
 
-→ open Issue が一覧表示 + 優先度・推奨アクション付き
-
-### 4.2 新規 Issue を起票
+### 3-B. 機能追加 (新機能・改修)
 
 ```
-/feature-add
+/issue-list                          # 現在の課題を見る
+/feature-add こうしたい               # Claude が Issue 化
+/feature-implement <Issue番号>        # TDD で実装 + PR 作成
+/feature-review-merge <PR番号>        # 内容説明 + マージ
 ```
 
-Claude が「どんな変更をしたいですか?」とヒアリング → Issue を作成
-
-> 💡 デモ会では既に起票済みの **Issue #26 (GA4 埋め込み)** を使うと早い
-
-### 4.3 実装
-
-```
-/feature-implement 26
-```
-
-Claude が:
-1. 仕様を読む
-2. 失敗テストを書く (RED)
-3. 最小実装 (GREEN)
-4. リファクタ + 全テスト (REFACTOR)
-5. secret-scan
-6. PR を作成
-
-### 4.4 PR レビュー → マージ
-
-```
-/feature-review-merge <PR番号>
-```
-
-Claude が変更内容を日本語で説明 → 「OK」と答えればマージ → 自動デプロイ
-
-### 4.5 本番反映確認
-
-数分後にブラウザで Ctrl+Shift+R → 動作確認
+> 💡 デモ会では既存の **Issue #26 (GA4 埋め込み)** を題材にすると 15 分で 1 巡できます。
 
 ---
 
-## STEP 5: LINE WORKS Bot を本番稼働 (30 分)
+## STEP 4: LINE WORKS Bot を本番稼働 (30 分)
 
-> **目的**: 寄付申込みが来たら運営トークルームに自動通知する仕組みを稼働
-> **使う skill**: `/lineworks-deploy`
-> **前提**: Phase 1 (LINE WORKS Developer Console での 6 点取得) が完了済み
+> **前提**: LINE WORKS Developer Console での認証情報 6 点取得 (Phase 1) が完了済み
 
 ```
 /lineworks-deploy
 ```
 
-Claude が以下を順に案内:
+Claude が対話的に進める:
 1. 認証情報 6 点が揃っているか確認
-2. clasp 認証 (開発者ドメイン)
-3. GAS にコードを push (`clasp push`)
-4. Script Properties に 6 点を投入 (GAS エディタの実行ダイアログ経由、Claude に値を渡さない)
-5. `testNotify` で疎通テスト
-6. `installFormSubmitTrigger` でトリガー登録
-7. 本番フォームから E2E テスト
-8. Issue #20 にコメントで完遂報告
-
-⚠️ **認証情報を Claude のチャットに貼り付けない**。GAS エディタの実行ダイアログから直接入力します。
+2. clasp push (コード反映)
+3. GAS エディタで `setupLineWorksProperties` を実行 (認証情報投入 — Claude には値を渡さない)
+4. `testNotify` で疎通テスト
+5. `installFormSubmitTrigger` でトリガー登録
+6. 本番フォームから E2E テスト
+7. Issue #20 に完遂報告
 
 ---
 
 # 📋 日常運用フロー (デモ後の継続業務)
 
-このセクションは **デモ会後にハンドブックを見返して** 使います。
-
-## 運用 A: 寄付申込みが来たとき (自動)
+## A. 寄付申込みが来たとき (自動)
 
 ```
 寄付者がフォーム送信
-   ↓
+  ↓
 スプレッドシートに行追加 (自動)
-   ↓
+  ↓
 運営トークルームに LINE WORKS 通知 (自動)
-   ↓
-[受信] 屋良 / 上間さんが内容確認
+  ↓
+屋良 / 上間さんが内容確認
 ```
 
-## 運用 B: 入金確認したとき (手動)
+## B. 入金確認 (手動)
 
-```
-振込確認後、スプレッドシートを開く
-   ↓
-該当行の I 列「振込確認ステータス」を「確認済」にする
-   ↓
-J 列に確認日 (yyyy-mm-dd)
-   ↓
-K 列に確認者
-   ↓
-翌朝 09:00 に HP に自動反映
-```
+スプレッドシートの I 列を「確認済」、J 列に確認日、K 列に確認者を入力。
+翌朝 09:00 JST に HP 自動反映。急ぐなら GitHub Actions タブで「Run workflow」。
 
-急いで反映したい場合:
-- GitHub Actions タブで `Deploy to GitHub Pages` ワークフローを「Run workflow」
+## C. コンテンツ更新
 
-## 運用 C: コンテンツ更新
-
-| やりたいこと | 使う skill |
+| やりたいこと | コマンド |
 |---|---|
-| 文言の修正 | `/site-update` |
-| 画像の差し替え | `/site-update` |
+| 文言・画像の修正 | `/site-update` |
 | 役員情報の更新 | `/site-update` |
 | 新ページ追加 | `/feature-add` → `/feature-implement` |
 
-## 運用 D: フォームを改修したとき
+## D. フォーム改修
 
-⚠️ **重要**: Form の項目を追加・削除すると Sheet の列順がずれて HP の集計が壊れる可能性。
+⚠️ Form の項目を変更すると Sheet の列順がずれて HP の集計が壊れる可能性。
 
 ```
 1. Form を変更
-2. /feature-add で「フォームに○○を E 列に追加。GAS と HP の集計も対応してほしい」と起票
+2. /feature-add  「フォームに○○を追加。GAS と HP の集計も対応してほしい」
 3. /feature-implement <Issue番号>
 4. /feature-review-merge <PR番号>
 ```
@@ -318,66 +201,40 @@ K 列に確認者
 
 # 🛟 困ったとき
 
-## トラブルシューティング
-
 | 症状 | 対処 |
 |---|---|
-| HP に反映されない | (1) Sheet の I 列が「確認済」か / (2) Ctrl+Shift+R で再読込 / (3) Actions タブで run 確認 |
-| LINE WORKS 通知が来ない | `/lineworks-deploy` を再実行して Step 4 から再確認 |
-| Claude Code でエラー | 日本語で「○○で詰まった」と聞く / `/setup-check` で再診断 |
-| `clasp push` が拒否される | 開発者ドメインで login しているか (`/setup-google-clis` 内で確認) |
-| Push protection エラー | コミットに API トークン等が紛れていないか確認 |
+| HP に反映されない | Sheet の I 列確認 + Ctrl+Shift+R で再読込 |
+| LINE WORKS 通知が来ない | `/lineworks-deploy` を再実行 |
+| エラーが出た | 日本語で Claude に「○○で詰まった」と聞く |
+| 環境が壊れた | `/setup-check` で再診断、ダメなら `/setup` |
+| Push 拒否 (secret-scan) | コミットに API トークン等が紛れていないか確認 |
 
-## 連絡先
-
+連絡先:
 - 急ぎ HP 修正: 神谷さんに Slack DM
-- LINE WORKS 関連: `/feature-add` で Issue 起票
-- 認証情報を失った: `docs/security/secret-handling.md` のローテーション手順
+- 認証情報を失った: `docs/security/secret-handling.md` 参照
 
 ---
 
 # 📖 リファレンス
 
-## skill / コマンド一覧
+## skill 一覧
 
-すべて Claude Code 内で `/コマンド名` で呼びます。
+すべて Claude Code 内で `/コマンド名` で呼ぶ:
 
-### 環境
-
-| skill | 用途 |
-|---|---|
-| `/setup` | 開発環境一括インストール |
-| `/setup-check` | 環境チェック |
-| `/setup-google-clis` | Google CLI 三種 (clasp/gws/gog) セットアップ + OAuth |
-
-### 既存システムを見る
-
-| skill | 用途 |
-|---|---|
-| `/system-tour` | Form / Sheet / GAS / Actions / Pages を画面で順に確認 |
-
-### サイト更新 (小修正)
-
-| skill | 用途 |
-|---|---|
-| `/site-preview` | ローカルプレビュー起動 |
-| `/site-update` | テキスト・画像の修正 |
-| `/site-publish` | 本番反映 |
-
-### 機能開発 (新機能・改修)
-
-| skill | 用途 |
-|---|---|
-| `/issue-list` | 課題一覧 |
-| `/feature-add` | 要望を Issue 化 |
-| `/feature-implement <N>` | Issue → 実装 → PR |
-| `/feature-review-merge <N>` | PR → 確認 → マージ |
-
-### LINE WORKS Bot
-
-| skill | 用途 |
-|---|---|
-| `/lineworks-deploy` | Phase 3〜5 (clasp push / Properties 投入 / testNotify / トリガー登録 / E2E) |
+| カテゴリ | コマンド | 用途 |
+|---|---|---|
+| **環境** | `/setup` | 全ツール一括インストール + 認証 (これ 1 つで OK) |
+| 環境 | `/setup-check` | 環境チェック |
+| 環境 | `/setup-google-clis` | gws / gog 追加 (オプション) |
+| **見る** | `/system-tour` | 既存システムを画面で順に確認 |
+| **更新** | `/site-preview` | ローカルプレビュー |
+| 更新 | `/site-update` | 文言・画像の修正 |
+| 更新 | `/site-publish` | 本番反映 |
+| **開発** | `/issue-list` | 課題一覧 |
+| 開発 | `/feature-add` | 要望を Issue 化 |
+| 開発 | `/feature-implement <N>` | Issue → 実装 → PR |
+| 開発 | `/feature-review-merge <N>` | PR → 確認 → マージ |
+| **運用** | `/lineworks-deploy` | LINE WORKS Bot 本番稼働 |
 
 ## 主要ファイル
 
@@ -397,37 +254,26 @@ K 列に確認者
 | GAS | Google Apps Script |
 | トリガー | GAS の自動実行設定 |
 | clasp | GAS をローカルから push する CLI |
-| Script Properties | GAS の機密情報保管庫 |
 | Issue | GitHub の課題管理 |
 | PR | Pull Request (変更案) |
 | CI | 自動テスト・チェック |
-| secret-scan | 秘密情報の誤コミット検出 |
 
 ## 参考リンク
 
-| カテゴリ | リンク |
-|---|---|
-| 雄飛会リポジトリ | <https://github.com/kaiho-yuuhikai/official-site> |
-| 雄飛会 HP | <https://kaiho-yuuhikai.jp/> |
-| 寄付承認手順 | `docs/operations/donation-confirmation.md` |
-| LINE WORKS 連携 | `docs/operations/line-works-notification-setup.md` |
-| セキュリティ | `docs/security/secret-handling.md` |
-| LINE WORKS Developers | <https://developers.worksmobile.com/jp/docs/> |
-| GAS リファレンス | <https://developers.google.com/apps-script/reference> |
+- リポジトリ: <https://github.com/kaiho-yuuhikai/official-site>
+- 公開サイト: <https://kaiho-yuuhikai.jp/>
+- LINE WORKS Developers: <https://developers.worksmobile.com/jp/docs/>
 
 ---
 
-# ✅ デモ会で踏むチェックリスト
-
-このハンドブックを上から順に進めれば全部触れます。
+# ✅ デモ会チェックリスト
 
 - [ ] `claude` でこのハンドブックを開きながら起動
-- [ ] STEP 1 `/setup` → `/setup-google-clis` → `/setup-check`
+- [ ] STEP 1 `/setup` → `/setup-check`
 - [ ] STEP 2 `/system-tour`
-- [ ] STEP 3 `/site-preview` → `/site-update` → `/site-publish`
-- [ ] STEP 4 `/issue-list` → `/feature-add` → `/feature-implement` → `/feature-review-merge`
-- [ ] STEP 5 `/lineworks-deploy`
-- [ ] 質疑応答 + 次回までの宿題確認
+- [ ] STEP 3-A `/site-preview` → `/site-update` → `/site-publish`
+- [ ] STEP 3-B `/issue-list` → `/feature-add` → `/feature-implement` → `/feature-review-merge`
+- [ ] STEP 4 `/lineworks-deploy`
+- [ ] 質疑応答
 
-🎓 **次のステップ**: デモ後の宿題は Issue #27 に集約しています。
-わからないことは Claude に日本語で聞くか、`/issue-list` で課題を確認してください。
+🎓 **次のステップ**: デモ後の宿題は Issue #27 に集約。わからないことは Claude に日本語で聞く。


### PR DESCRIPTION
## Summary

これまでの議論を踏まえてハンドブックを大幅簡略化。

## 主な変更

| 旧 | 新 |
|---|---|
| STEP 5 つ (setup → setup-google-clis → tour → 変更 → 機能 → bot) | **STEP 4 つ** (setup → tour → 変更/機能 → bot) |
| /setup-google-clis が clasp/gws/gog 全部 | **/setup** に clasp 含めて統合 |
| gws/gog 必須扱い | **オプション扱い**。gws auth setup の GCP OAuth クライアント手動作成問題が判明したため |

## 経緯

`gws auth setup` 実行で「OAuth client creation requires manual setup in the Google Cloud Console」エラー発生。
別案件用 GCP プロジェクト (`jfc-japan-ai-platform-dev`) が active で、雄飛会専用クライアント未作成。

→ 雄飛会の最小運用は **clasp + 既存 GAS** で完結することを確認したため、gws/gog をオプションに格下げ。

## skill の役割再定義

| skill | 役割 |
|---|---|
| /setup | **全部入り (clasp 含む)。これ 1 つで OK** |
| /setup-check | 環境チェック |
| /setup-google-clis | **gws / gog 追加 (オプション)** + GCP OAuth クライアント作成手順 |
| /system-tour | 既存システムを画面で見る |
| /site-update / /site-publish | サイト更新 |
| /feature-add / /feature-implement / /feature-review-merge | 機能開発 |
| /lineworks-deploy | LINE WORKS Bot 稼働 |

ビジネスユーザーが覚えるのは `claude` 起動コマンド 1 つだけ、というポリシーを維持。

## Test plan

- [x] secret-scan 違反 0
- [x] 全 skill が Claude Code に登録される
- [ ] (デモ会中) ハンドブックを上から順に進めて完走確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)